### PR TITLE
Handle well-being color statuses and configure Tailwind toolchain

### DIFF
--- a/Ascenda Padrinho att/package.json
+++ b/Ascenda Padrinho att/package.json
@@ -19,6 +19,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.18",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
     "vite": "^5.2.0"
   }
 }

--- a/Ascenda Padrinho att/postcss.config.js
+++ b/Ascenda Padrinho att/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/Ascenda Padrinho att/src/Layout.jsx
+++ b/Ascenda Padrinho att/src/Layout.jsx
@@ -83,35 +83,61 @@ function LayoutContent({ children }) {
       <style>{`
         :root {
           --bg: #F8F9FB;
+          --bg-rgb: 248 249 251;
           --surface: #FFFFFF;
+          --surface-rgb: 255 255 255;
           --surface-2: #F1F3F5;
+          --surface-2-rgb: 241 243 245;
           --text-primary: #1F2430;
+          --text-primary-rgb: 31 36 48;
           --text-secondary: #4B5563;
+          --text-secondary-rgb: 75 85 99;
           --text-muted: #6B7280;
+          --text-muted-rgb: 107 114 128;
           --brand: #8A2BE2;
+          --brand-rgb: 138 43 226;
           --brand-2: #FF6B35;
+          --brand-2-rgb: 255 107 53;
           --border: #E5E7EB;
+          --border-rgb: 229 231 235;
           --success: #16A34A;
+          --success-rgb: 22 163 74;
           --warning: #F59E0B;
+          --warning-rgb: 245 158 11;
           --error: #E94560;
+          --error-rgb: 233 69 96;
           --ring: #8A2BE2;
+          --ring-rgb: 138 43 226;
           --shadow-color: 17, 24, 39;
         }
 
         :root.dark {
           --bg: #0F0F1F;
+          --bg-rgb: 15 15 31;
           --surface: #151A2A;
+          --surface-rgb: 21 26 42;
           --surface-2: #1A2032;
+          --surface-2-rgb: 26 32 50;
           --text-primary: #EAEAF0;
+          --text-primary-rgb: 234 234 240;
           --text-secondary: #C7CBD6;
+          --text-secondary-rgb: 199 203 214;
           --text-muted: #9AA3B2;
+          --text-muted-rgb: 154 163 178;
           --brand: #B390E0;
+          --brand-rgb: 179 144 224;
           --brand-2: #FF814F;
+          --brand-2-rgb: 255 129 79;
           --border: #2B3247;
+          --border-rgb: 43 50 71;
           --success: #22C55E;
+          --success-rgb: 34 197 94;
           --warning: #FBBF24;
+          --warning-rgb: 251 191 36;
           --error: #F06277;
+          --error-rgb: 240 98 119;
           --ring: #B390E0;
+          --ring-rgb: 179 144 224;
           --shadow-color: 0, 0, 0;
         }
 

--- a/Ascenda Padrinho att/src/components/dashboard/InternStatusCard.jsx
+++ b/Ascenda Padrinho att/src/components/dashboard/InternStatusCard.jsx
@@ -9,7 +9,7 @@ import { RadialBarChart, RadialBar, ResponsiveContainer } from "recharts";
 import Avatar from "../ui/Avatar";
 import { getDaysLeft, getDaysLeftBadgeColor, getInternshipProgress } from "../utils/dates";
 
-const wellBeingIcons = {
+const wellBeingVariants = {
   "Excellent": { icon: Smile, color: "text-success", bg: "bg-success/10" },
   "Good": { icon: Smile, color: "text-blue-500", bg: "bg-blue-500/10" },
   "Neutral": { icon: Meh, color: "text-warning", bg: "bg-warning/10" },
@@ -17,8 +17,27 @@ const wellBeingIcons = {
   "Overwhelmed": { icon: Annoyed, color: "text-error", bg: "bg-error/10" }
 };
 
+const wellBeingAliases = {
+  "excellent": "Excellent",
+  "good": "Good",
+  "neutral": "Neutral",
+  "stressed": "Stressed",
+  "overwhelmed": "Overwhelmed",
+  "green": "Excellent",
+  "yellow": "Neutral",
+  "red": "Overwhelmed"
+};
+
 export default function InternStatusCard({ intern, onStatusToggle, index }) {
-  const wellBeing = wellBeingIcons[intern.well_being_status] || wellBeingIcons["Neutral"];
+  const rawStatus = intern.well_being_status;
+  const normalizedStatus = typeof rawStatus === "string"
+    ? rawStatus.trim().toLowerCase()
+    : undefined;
+  const canonicalStatus = normalizedStatus && wellBeingAliases[normalizedStatus]
+    ? wellBeingAliases[normalizedStatus]
+    : rawStatus;
+
+  const wellBeing = wellBeingVariants[canonicalStatus] || wellBeingVariants["Neutral"];
   const WellBeingIcon = wellBeing.icon;
   const isActive = intern.status === 'active';
   
@@ -67,9 +86,9 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
                     {intern.full_name}
                   </h3>
                   {intern.well_being_status && (
-                    <div 
+                    <div
                       className={`p-1.5 rounded-lg ${wellBeing.bg}`}
-                      title={`Well-being: ${intern.well_being_status}`}
+                      title={`Well-being: ${canonicalStatus || intern.well_being_status || 'Unknown'}`}
                     >
                       <WellBeingIcon className={`w-4 h-4 ${wellBeing.color}`} />
                     </div>

--- a/Ascenda Padrinho att/src/index.css
+++ b/Ascenda Padrinho att/src/index.css
@@ -1,28 +1,31 @@
-* {
-  box-sizing: border-box;
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
-body {
-  margin: 0;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: #f8f9fb;
-  color: #1f2430;
-}
+@layer base {
+  * {
+    box-sizing: border-box;
+  }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
+  body {
+    @apply m-0 bg-bg font-sans text-primary;
+  }
 
-button {
-  font-family: inherit;
-}
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 
-:root {
-  color-scheme: light;
-}
+  button {
+    font-family: inherit;
+  }
 
-:root.dark {
-  color-scheme: dark;
+  :root {
+    color-scheme: light;
+  }
+
+  :root.dark {
+    color-scheme: dark;
+  }
 }
 

--- a/Ascenda Padrinho att/tailwind.config.js
+++ b/Ascenda Padrinho att/tailwind.config.js
@@ -1,0 +1,40 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
+const withOpacityValue = (variable) => ({ opacityValue } = {}) => {
+  if (opacityValue === undefined) {
+    return `rgb(var(${variable}) / 1)`;
+  }
+  return `rgb(var(${variable}) / ${opacityValue})`;
+};
+
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        bg: withOpacityValue('--bg-rgb'),
+        surface: withOpacityValue('--surface-rgb'),
+        surface2: withOpacityValue('--surface-2-rgb'),
+        primary: withOpacityValue('--text-primary-rgb'),
+        secondary: withOpacityValue('--text-secondary-rgb'),
+        muted: withOpacityValue('--text-muted-rgb'),
+        brand: withOpacityValue('--brand-rgb'),
+        brand2: withOpacityValue('--brand-2-rgb'),
+        success: withOpacityValue('--success-rgb'),
+        warning: withOpacityValue('--warning-rgb'),
+        error: withOpacityValue('--error-rgb'),
+        border: withOpacityValue('--border-rgb'),
+        ring: withOpacityValue('--ring-rgb'),
+      },
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
+      transitionDuration: {
+        350: '350ms',
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- map color-coded well-being values to semantic icon/color variants in the intern status card
- retain a neutral fallback while improving tooltip labeling for unknown well-being statuses
- add a Tailwind/PostCSS pipeline and expose RGB versions of the existing theme tokens so Tailwind utilities render with opacity variants
- replace the global stylesheet with Tailwind layers to keep the reset and typography aligned with Tailwind classes

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68dea48f0210832dba6f0d210d04c5d0