### PR TITLE
refactor: migrate router to future flags

### DIFF
--- a/Ascenda Padrinho att/src/App.jsx
+++ b/Ascenda Padrinho att/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 import Layout from './Layout.jsx';
 import Dashboard from './pages/Dashboard.jsx';
 import Interns from './pages/Interns.jsx';
@@ -8,20 +8,45 @@ import VacationRequests from './pages/VacationRequests.jsx';
 import Reports from './pages/Reports.jsx';
 import { PAGE_URLS } from './utils/index.js';
 
+const router = createBrowserRouter([
+  {
+    path: PAGE_URLS.Dashboard,
+    element: <Layout />,
+    children: [
+      {
+        index: true,
+        element: <Dashboard />,
+      },
+      {
+        path: PAGE_URLS.Interns.replace(/^\//, ''),
+        element: <Interns />,
+      },
+      {
+        path: PAGE_URLS.ContentManagement.replace(/^\//, ''),
+        element: <ContentManagement />,
+      },
+      {
+        path: PAGE_URLS.VacationRequests.replace(/^\//, ''),
+        element: <VacationRequests />,
+      },
+      {
+        path: PAGE_URLS.Reports.replace(/^\//, ''),
+        element: <Reports />,
+      },
+      {
+        path: '*',
+        element: <Navigate to={PAGE_URLS.Dashboard} replace />,
+      },
+    ],
+  },
+]);
+
 export default function App() {
   return (
-    <BrowserRouter>
-      <Layout>
-        <Routes>
-          <Route path={PAGE_URLS.Dashboard} element={<Dashboard />} />
-          <Route path={PAGE_URLS.Interns} element={<Interns />} />
-          <Route path={PAGE_URLS.ContentManagement} element={<ContentManagement />} />
-          <Route path={PAGE_URLS.VacationRequests} element={<VacationRequests />} />
-          <Route path={PAGE_URLS.Reports} element={<Reports />} />
-          <Route path="*" element={<Navigate to={PAGE_URLS.Dashboard} replace />} />
-        </Routes>
-      </Layout>
-    </BrowserRouter>
+    <RouterProvider
+      router={router}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    />
   );
 }
 

--- a/Ascenda Padrinho att/src/Layout.jsx
+++ b/Ascenda Padrinho att/src/Layout.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, Outlet, useLocation } from "react-router-dom";
 import { createPageUrl } from "@/utils";
 import { 
   LayoutDashboard, 
@@ -58,7 +58,7 @@ const navigationItems = [
   },
 ];
 
-function LayoutContent({ children }) {
+function LayoutContent() {
   const location = useLocation();
   const [user, setUser] = React.useState(null);
 
@@ -288,7 +288,7 @@ function LayoutContent({ children }) {
           </header>
 
           <div className="flex-1 overflow-auto">
-            {children}
+            <Outlet />
           </div>
         </main>
       </div>
@@ -296,10 +296,10 @@ function LayoutContent({ children }) {
   );
 }
 
-export default function Layout({ children }) {
+export default function Layout() {
   return (
     <ThemeProvider>
-      <LayoutContent>{children}</LayoutContent>
+      <LayoutContent />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary
- switch App routing to a createBrowserRouter + RouterProvider configured with the required future flags
- convert the shared layout to render nested routes through an Outlet so child pages remain accessible

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68df274f6108832daba56458caaea876