### PR TITLE
Add localization provider, translations, and UI toggle

### DIFF
--- a/Ascenda Padrinho att/src/Layout.jsx
+++ b/Ascenda Padrinho att/src/Layout.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { createPageUrl } from "@/utils";
-import { 
-  LayoutDashboard, 
-  Users, 
-  BookOpen, 
+import {
+  LayoutDashboard,
+  Users,
+  BookOpen,
   BarChart3,
   Calendar,
   Sparkles,
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { User } from "@/entities/User";
 import { ThemeProvider } from "./components/theme/ThemeProvider";
 import ThemeToggle from "./components/theme/ThemeToggle";
+import LanguageToggle from "./components/theme/LanguageToggle";
 import NotificationBell from "./components/notifications/NotificationBell";
 import {
   Sidebar,
@@ -29,30 +30,30 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
-
+import { LanguageProvider, useTranslation } from "@/i18n";
 const navigationItems = [
   {
-    title: "Dashboard",
+    titleKey: "layout.nav.dashboard",
     url: createPageUrl("Dashboard"),
     icon: LayoutDashboard,
   },
   {
-    title: "Team Overview",
+    titleKey: "layout.nav.interns",
     url: createPageUrl("Interns"),
     icon: Users,
   },
   {
-    title: "Content Management",
+    titleKey: "layout.nav.content",
     url: createPageUrl("ContentManagement"),
     icon: BookOpen,
   },
   {
-    title: "Vacation Requests",
+    titleKey: "layout.nav.vacation",
     url: createPageUrl("VacationRequests"),
     icon: Calendar,
   },
   {
-    title: "Reports",
+    titleKey: "layout.nav.reports",
     url: createPageUrl("Reports"),
     icon: BarChart3,
   },
@@ -61,6 +62,7 @@ const navigationItems = [
 function LayoutContent() {
   const location = useLocation();
   const [user, setUser] = React.useState(null);
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     const loadUser = async () => {
@@ -202,34 +204,34 @@ function LayoutContent() {
                 </div>
               </div>
               <div>
-                <h2 className="font-bold text-primary">Ascenda</h2>
-                <p className="text-xs text-muted">Manager Portal</p>
+                <h2 className="font-bold text-primary">{t("common.appName")}</h2>
+                <p className="text-xs text-muted">{t("common.managerPortal")}</p>
               </div>
             </div>
           </SidebarHeader>
-          
+
           <SidebarContent className="p-3">
             <SidebarGroup>
               <SidebarGroupLabel className="text-xs font-medium text-muted uppercase tracking-wider px-3 py-2">
-                Navigation
+                {t("common.navigation")}
               </SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu>
                   {navigationItems.map((item) => {
                     const isActive = location.pathname === item.url;
                     return (
-                      <SidebarMenuItem key={item.title}>
-                        <SidebarMenuButton 
-                          asChild 
+                      <SidebarMenuItem key={item.titleKey}>
+                        <SidebarMenuButton
+                          asChild
                           className={`transition-all duration-200 rounded-xl mb-1 ${
-                            isActive 
-                              ? 'bg-brand text-white hover:bg-brand' 
+                            isActive
+                              ? 'bg-brand text-white hover:bg-brand'
                               : 'hover:bg-surface2 text-secondary hover:text-primary'
                           }`}
                         >
                           <Link to={item.url} className="flex items-center gap-3 px-4 py-3">
                             <item.icon className="w-5 h-5" />
-                            <span className="font-medium">{item.title}</span>
+                            <span className="font-medium">{t(item.titleKey)}</span>
                           </Link>
                         </SidebarMenuButton>
                       </SidebarMenuItem>
@@ -243,6 +245,7 @@ function LayoutContent() {
           <SidebarFooter className="border-t border-border p-4 space-y-3">
             <div className="flex gap-2">
               <ThemeToggle />
+              <LanguageToggle />
               <NotificationBell />
             </div>
             {user && (
@@ -250,12 +253,12 @@ function LayoutContent() {
                 <div className="flex items-center gap-3 mb-3">
                   <div className="w-10 h-10 bg-gradient-to-br from-brand to-brand2 rounded-full flex items-center justify-center">
                     <span className="text-white font-bold text-sm">
-                      {user.full_name?.charAt(0) || 'M'}
+                      {user.full_name?.charAt(0) || t("common.manager").charAt(0)}
                     </span>
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className="font-semibold text-primary text-sm truncate">
-                      {user.full_name || 'Manager'}
+                      {user.full_name || t("common.manager")}
                     </p>
                     <p className="text-xs text-muted truncate">
                       {user.email}
@@ -269,7 +272,7 @@ function LayoutContent() {
                   className="w-full text-secondary hover:text-primary hover:bg-surface2"
                 >
                   <LogOut className="w-4 h-4 mr-2" />
-                  Logout
+                  {t("common.actions.logout")}
                 </Button>
               </div>
             )}
@@ -280,7 +283,7 @@ function LayoutContent() {
           <header className="bg-surface border-b border-border px-6 py-4 md:hidden shadow-e1">
             <div className="flex items-center gap-4">
               <SidebarTrigger className="hover:bg-surface2 p-2 rounded-lg transition-colors duration-200 text-secondary" />
-              <h1 className="text-xl font-bold text-primary">Ascenda</h1>
+              <h1 className="text-xl font-bold text-primary">{t("common.appName")}</h1>
               <div className="ml-auto flex gap-2">
                 <NotificationBell />
               </div>
@@ -298,8 +301,10 @@ function LayoutContent() {
 
 export default function Layout() {
   return (
-    <ThemeProvider>
-      <LayoutContent />
-    </ThemeProvider>
+    <LanguageProvider>
+      <ThemeProvider>
+        <LayoutContent />
+      </ThemeProvider>
+    </LanguageProvider>
   );
 }

--- a/Ascenda Padrinho att/src/components/chat/ChatDrawer.jsx
+++ b/Ascenda Padrinho att/src/components/chat/ChatDrawer.jsx
@@ -4,23 +4,34 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Send } from "lucide-react";
 import { ChatMessage } from "@/entities/ChatMessage";
-import { format } from "date-fns";
 import { eventBus, EventTypes } from "../utils/eventBus";
+import { useLanguage, useTranslation } from "@/i18n";
 
 export default function ChatDrawer({ isOpen, onClose, intern }) {
   const [messages, setMessages] = useState([]);
   const [newMessage, setNewMessage] = useState("");
   const [isSending, setIsSending] = useState(false);
   const messagesEndRef = useRef(null);
+  const { t } = useTranslation();
+  const { language } = useLanguage();
+
+  const timeFormatter = React.useMemo(
+    () =>
+      new Intl.DateTimeFormat(language === "pt" ? "pt-BR" : "en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+      }),
+    [language]
+  );
 
   const loadMessages = useCallback(async () => {
     if (!intern) return;
     const data = await ChatMessage.filter({ intern_id: intern.id }, '-created_date');
     setMessages(data.reverse());
     
-    const unreadMessages = data.filter(m => m.from === 'intern' && !m.read);
+    const unreadMessages = data.filter((m) => m.from === "intern" && !m.read);
     await Promise.all(
-      unreadMessages.map(m => ChatMessage.update(m.id, { read: true }))
+      unreadMessages.map((m) => ChatMessage.update(m.id, { read: true }))
     );
   }, [intern]);
 
@@ -61,7 +72,7 @@ export default function ChatDrawer({ isOpen, onClose, intern }) {
   }, [newMessage, intern, isSending, loadMessages]);
 
   const handleKeyDown = useCallback((e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend(e);
     }
@@ -79,7 +90,7 @@ export default function ChatDrawer({ isOpen, onClose, intern }) {
             </div>
             <div>
               <SheetTitle className="text-primary">{intern.full_name}</SheetTitle>
-              <p className="text-xs text-muted">Chat conversation</p>
+              <p className="text-xs text-muted">{t("chat.title")}</p>
             </div>
           </div>
         </SheetHeader>
@@ -88,20 +99,22 @@ export default function ChatDrawer({ isOpen, onClose, intern }) {
           {messages.map((message) => (
             <div
               key={message.id}
-              className={`flex ${message.from === 'manager' ? 'justify-end' : 'justify-start'}`}
+              className={`flex ${
+                message.from === "manager" ? "justify-end" : "justify-start"
+              }`}
             >
               <div
                 className={`max-w-[80%] rounded-xl p-3 ${
-                  message.from === 'manager'
-                    ? 'bg-brand text-white'
-                    : 'bg-surface2 text-primary border border-border'
+                  message.from === "manager"
+                    ? "bg-brand text-white"
+                    : "bg-surface2 text-primary border border-border"
                 }`}
               >
                 <p className="text-sm whitespace-pre-wrap break-words">{message.text}</p>
                 <p className={`text-xs mt-1 ${
-                  message.from === 'manager' ? 'text-white/70' : 'text-muted'
+                  message.from === "manager" ? "text-white/70" : "text-muted"
                 }`}>
-                  {format(new Date(message.created_date), 'h:mm a')}
+                  {timeFormatter.format(new Date(message.created_date))}
                 </p>
               </div>
             </div>
@@ -110,7 +123,7 @@ export default function ChatDrawer({ isOpen, onClose, intern }) {
           
           {messages.length === 0 && (
             <div className="text-center py-8">
-              <p className="text-muted">No messages yet. Start the conversation!</p>
+              <p className="text-muted">{t("chat.empty")}</p>
             </div>
           )}
         </div>
@@ -121,7 +134,7 @@ export default function ChatDrawer({ isOpen, onClose, intern }) {
               value={newMessage}
               onChange={(e) => setNewMessage(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder="Type a message... (Enter to send, Shift+Enter for new line)"
+              placeholder={t("chat.placeholder")}
               className="bg-surface2 border-border text-primary placeholder:text-muted resize-none"
               rows={2}
             />

--- a/Ascenda Padrinho att/src/components/content/CourseCard.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseCard.jsx
@@ -5,9 +5,23 @@ import { Button } from "@/components/ui/button";
 import { BookOpen, Clock, Users, TrendingUp, Pencil, Eye, Youtube, FileText, UserPlus } from "lucide-react";
 import { motion } from "framer-motion";
 import { CourseAssignment } from "@/entities/CourseAssignment";
+import { useTranslation } from "@/i18n";
 
 export default function CourseCard({ course, index, onEdit, onPreview, onAssign }) {
   const [assignmentCount, setAssignmentCount] = useState(0);
+  const { t } = useTranslation();
+  const categoryLabels = React.useMemo(() => ({
+    "Technical": t("courseForm.categories.technical"),
+    "Leadership": t("courseForm.categories.leadership"),
+    "Communication": t("courseForm.categories.communication"),
+    "Design": t("courseForm.categories.design"),
+    "Business": t("courseForm.categories.business"),
+  }), [t]);
+  const difficultyLabels = React.useMemo(() => ({
+    "Beginner": t("courseForm.difficulties.beginner"),
+    "Intermediate": t("courseForm.difficulties.intermediate"),
+    "Advanced": t("courseForm.difficulties.advanced"),
+  }), [t]);
 
   useEffect(() => {
     const loadAssignments = async () => {
@@ -59,27 +73,27 @@ export default function CourseCard({ course, index, onEdit, onPreview, onAssign 
 
             <div className="flex flex-wrap gap-2">
               <Badge className={categoryColors[course.category] + " border"}>
-                {course.category}
+                {categoryLabels[course.category] || course.category}
               </Badge>
               <Badge className={difficultyColors[course.difficulty] + " border"}>
-                {course.difficulty}
+                {difficultyLabels[course.difficulty] || course.difficulty}
               </Badge>
               {course.youtube_video_id && (
                 <Badge variant="outline" className="border-error/30 text-error bg-error/10">
                   <Youtube className="w-3 h-3 mr-1" />
-                  YouTube
+                  {t("courseCard.youtube")}
                 </Badge>
               )}
               {course.file_url && (
                 <Badge variant="outline" className="border-brand/30 text-brand bg-brand/10">
                   <FileText className="w-3 h-3 mr-1" />
-                  {course.file_name || 'File'}
+                  {course.file_name || t("common.misc.file")}
                 </Badge>
               )}
               {assignmentCount > 0 && (
                 <Badge variant="outline" className="border-brand2/30 text-brand2 bg-brand2/10">
                   <Users className="w-3 h-3 mr-1" />
-                  {assignmentCount} active
+                  {t("courseCard.active", { count: assignmentCount })}
                 </Badge>
               )}
             </div>
@@ -115,7 +129,7 @@ export default function CourseCard({ course, index, onEdit, onPreview, onAssign 
                 className="border-border hover:bg-surface2"
               >
                 <Pencil className="w-4 h-4 mr-2" />
-                Edit
+                {t("courseCard.edit")}
               </Button>
               <Button
                 variant="outline"
@@ -124,7 +138,7 @@ export default function CourseCard({ course, index, onEdit, onPreview, onAssign 
                 className="border-brand2/30 hover:bg-brand2/10 text-brand2"
               >
                 <UserPlus className="w-4 h-4 mr-2" />
-                Assign
+                {t("courseCard.assign")}
               </Button>
               {hasMedia && (
                 <Button
@@ -134,7 +148,7 @@ export default function CourseCard({ course, index, onEdit, onPreview, onAssign 
                   className="col-span-2 border-brand/30 hover:bg-brand/10 text-brand"
                 >
                   <Eye className="w-4 h-4 mr-2" />
-                  Preview
+                  {t("courseCard.preview")}
                 </Button>
               )}
             </div>

--- a/Ascenda Padrinho att/src/components/content/CourseEditModal.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseEditModal.jsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/select";
 import { Loader2, Youtube } from "lucide-react";
 import YouTubePreview from "./YouTubePreview";
+import { useTranslation } from "@/i18n";
 
 export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
   const [formData, setFormData] = useState({
@@ -25,6 +26,7 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
     youtube_video_id: ""
   });
   const [isSaving, setIsSaving] = useState(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (course) {
@@ -80,12 +82,12 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-2xl bg-surface border-border text-primary">
         <DialogHeader>
-          <DialogTitle className="text-primary">Edit Course</DialogTitle>
+          <DialogTitle className="text-primary">{t("courseEdit.title")}</DialogTitle>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <Label htmlFor="edit-title" className="text-secondary">Course Title *</Label>
+            <Label htmlFor="edit-title" className="text-secondary">{t("courseForm.titleLabel")}</Label>
             <Input
               id="edit-title"
               value={formData.title}
@@ -96,7 +98,7 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
           </div>
 
           <div>
-            <Label htmlFor="edit-description" className="text-secondary">Description *</Label>
+            <Label htmlFor="edit-description" className="text-secondary">{t("courseForm.descriptionLabel")}</Label>
             <Textarea
               id="edit-description"
               value={formData.description}
@@ -108,37 +110,37 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
 
           <div className="grid grid-cols-3 gap-4">
             <div>
-              <Label htmlFor="edit-category" className="text-secondary">Category</Label>
+              <Label htmlFor="edit-category" className="text-secondary">{t("courseForm.categoryLabel")}</Label>
               <Select value={formData.category} onValueChange={(value) => setFormData({ ...formData, category: value })}>
                 <SelectTrigger className="bg-surface2 border-border text-primary">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-surface border-border">
-                  <SelectItem value="Technical">Technical</SelectItem>
-                  <SelectItem value="Leadership">Leadership</SelectItem>
-                  <SelectItem value="Communication">Communication</SelectItem>
-                  <SelectItem value="Design">Design</SelectItem>
-                  <SelectItem value="Business">Business</SelectItem>
+                  <SelectItem value="Technical">{t("courseForm.categories.technical")}</SelectItem>
+                  <SelectItem value="Leadership">{t("courseForm.categories.leadership")}</SelectItem>
+                  <SelectItem value="Communication">{t("courseForm.categories.communication")}</SelectItem>
+                  <SelectItem value="Design">{t("courseForm.categories.design")}</SelectItem>
+                  <SelectItem value="Business">{t("courseForm.categories.business")}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             <div>
-              <Label htmlFor="edit-difficulty" className="text-secondary">Difficulty</Label>
+              <Label htmlFor="edit-difficulty" className="text-secondary">{t("courseForm.difficultyLabel")}</Label>
               <Select value={formData.difficulty} onValueChange={(value) => setFormData({ ...formData, difficulty: value })}>
                 <SelectTrigger className="bg-surface2 border-border text-primary">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-surface border-border">
-                  <SelectItem value="Beginner">Beginner</SelectItem>
-                  <SelectItem value="Intermediate">Intermediate</SelectItem>
-                  <SelectItem value="Advanced">Advanced</SelectItem>
+                  <SelectItem value="Beginner">{t("courseForm.difficulties.beginner")}</SelectItem>
+                  <SelectItem value="Intermediate">{t("courseForm.difficulties.intermediate")}</SelectItem>
+                  <SelectItem value="Advanced">{t("courseForm.difficulties.advanced")}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             <div>
-              <Label htmlFor="edit-duration" className="text-secondary">Duration (hours)</Label>
+              <Label htmlFor="edit-duration" className="text-secondary">{t("courseForm.durationLabel")}</Label>
               <Input
                 id="edit-duration"
                 type="number"
@@ -153,17 +155,17 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
           <div>
             <Label htmlFor="edit-youtube" className="text-secondary flex items-center gap-2">
               <Youtube className="w-4 h-4 text-error" />
-              YouTube Link (Optional)
+              {t("courseForm.youtubeLabel")}
             </Label>
             <Input
               id="edit-youtube"
               value={formData.youtube_url}
               onChange={(e) => setFormData({ ...formData, youtube_url: e.target.value })}
-              placeholder="https://www.youtube.com/watch?v=..."
+              placeholder={t("common.placeholders.youtubeUrl")}
               className="bg-surface2 border-border text-primary placeholder:text-muted"
             />
-            <YouTubePreview 
-              url={formData.youtube_url} 
+            <YouTubePreview
+              url={formData.youtube_url}
               onVideoIdChange={handleVideoIdChange}
             />
           </div>
@@ -175,7 +177,7 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
               onClick={onClose}
               className="border-border"
             >
-              Cancel
+              {t("common.actions.cancel")}
             </Button>
             <Button
               type="submit"
@@ -185,10 +187,10 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
               {isSaving ? (
                 <>
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  Saving...
+                  {t("common.actions.saving")}
                 </>
               ) : (
-                "Save Changes"
+                t("courseEdit.save")
               )}
             </Button>
           </DialogFooter>

--- a/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
@@ -14,6 +14,7 @@ import {
 import { UploadFile } from "@/integrations/Core";
 import { Upload, Loader2, Youtube, Eye } from "lucide-react";
 import YouTubePreview from "./YouTubePreview";
+import { useTranslation } from "@/i18n";
 
 export default function CourseUploadForm({ onSuccess, onPreview }) {
   const [formData, setFormData] = useState({
@@ -29,6 +30,7 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
   const [isUploading, setIsUploading] = useState(false);
   const [file, setFile] = useState(null);
   const [previewData, setPreviewData] = useState(null);
+  const { t } = useTranslation();
 
   const handleFileChange = React.useCallback(async (e) => {
     const selectedFile = e.target.files[0];
@@ -121,30 +123,30 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
       <CardHeader>
         <CardTitle className="text-primary flex items-center gap-2">
           <Upload className="w-5 h-5" />
-          Add New Course
+          {t("content.addCourse")}
         </CardTitle>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <Label htmlFor="title" className="text-secondary">Course Title *</Label>
+            <Label htmlFor="title" className="text-secondary">{t("courseForm.titleLabel")}</Label>
             <Input
               id="title"
               value={formData.title}
               onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-              placeholder="e.g., Advanced React Patterns"
+              placeholder={t("common.placeholders.courseTitleExample")}
               required
               className="bg-surface2 border-border text-primary placeholder:text-muted"
             />
           </div>
 
           <div>
-            <Label htmlFor="description" className="text-secondary">Description *</Label>
+            <Label htmlFor="description" className="text-secondary">{t("courseForm.descriptionLabel")}</Label>
             <Textarea
               id="description"
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-              placeholder="What will interns learn?"
+              placeholder={t("common.placeholders.courseDescription")}
               required
               className="bg-surface2 border-border text-primary placeholder:text-muted h-24"
             />
@@ -152,37 +154,37 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <Label htmlFor="category" className="text-secondary">Category</Label>
+              <Label htmlFor="category" className="text-secondary">{t("courseForm.categoryLabel")}</Label>
               <Select value={formData.category} onValueChange={(value) => setFormData({ ...formData, category: value })}>
                 <SelectTrigger className="bg-surface2 border-border text-primary">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-surface border-border">
-                  <SelectItem value="Technical">Technical</SelectItem>
-                  <SelectItem value="Leadership">Leadership</SelectItem>
-                  <SelectItem value="Communication">Communication</SelectItem>
-                  <SelectItem value="Design">Design</SelectItem>
-                  <SelectItem value="Business">Business</SelectItem>
+                  <SelectItem value="Technical">{t("courseForm.categories.technical")}</SelectItem>
+                  <SelectItem value="Leadership">{t("courseForm.categories.leadership")}</SelectItem>
+                  <SelectItem value="Communication">{t("courseForm.categories.communication")}</SelectItem>
+                  <SelectItem value="Design">{t("courseForm.categories.design")}</SelectItem>
+                  <SelectItem value="Business">{t("courseForm.categories.business")}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             <div>
-              <Label htmlFor="difficulty" className="text-secondary">Difficulty</Label>
+              <Label htmlFor="difficulty" className="text-secondary">{t("courseForm.difficultyLabel")}</Label>
               <Select value={formData.difficulty} onValueChange={(value) => setFormData({ ...formData, difficulty: value })}>
                 <SelectTrigger className="bg-surface2 border-border text-primary">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-surface border-border">
-                  <SelectItem value="Beginner">Beginner</SelectItem>
-                  <SelectItem value="Intermediate">Intermediate</SelectItem>
-                  <SelectItem value="Advanced">Advanced</SelectItem>
+                  <SelectItem value="Beginner">{t("courseForm.difficulties.beginner")}</SelectItem>
+                  <SelectItem value="Intermediate">{t("courseForm.difficulties.intermediate")}</SelectItem>
+                  <SelectItem value="Advanced">{t("courseForm.difficulties.advanced")}</SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             <div>
-              <Label htmlFor="duration" className="text-secondary">Duration (hours)</Label>
+              <Label htmlFor="duration" className="text-secondary">{t("courseForm.durationLabel")}</Label>
               <Input
                 id="duration"
                 type="number"
@@ -198,29 +200,29 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
           <div>
             <Label htmlFor="youtube" className="text-secondary flex items-center gap-2">
               <Youtube className="w-4 h-4 text-error" />
-              YouTube Link (Optional)
+              {t("courseForm.youtubeLabel")}
             </Label>
             <Input
               id="youtube"
               value={formData.youtube_url}
               onChange={(e) => setFormData({ ...formData, youtube_url: e.target.value })}
-              placeholder="https://www.youtube.com/watch?v=..."
+              placeholder={t("common.placeholders.youtubeUrl")}
               className="bg-surface2 border-border text-primary placeholder:text-muted"
             />
-            <YouTubePreview 
-              url={formData.youtube_url} 
+            <YouTubePreview
+              url={formData.youtube_url}
               onVideoIdChange={handleVideoIdChange}
             />
           </div>
 
           <div>
-            <Label htmlFor="file" className="text-secondary">Course Materials (Optional)</Label>
+            <Label htmlFor="file" className="text-secondary">{t("courseForm.materialsLabel")}</Label>
             <div className="mt-2">
               <label className="flex items-center justify-center w-full h-32 border-2 border-dashed border-border rounded-xl cursor-pointer hover:border-brand transition-colors bg-surface2">
                 <div className="text-center">
                   <Upload className="w-8 h-8 mx-auto mb-2 text-brand" />
                   <span className="text-sm text-muted">
-                    {file ? file.name : "Click to upload PDF, video, image, or Office file"}
+                    {file ? file.name : t("common.placeholders.uploadPrompt")}
                   </span>
                   {file && (
                     <span className="text-xs text-muted block mt-1">
@@ -247,7 +249,7 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
               className="w-full border-brand/30 hover:bg-brand/10 text-brand"
             >
               <Eye className="w-4 h-4 mr-2" />
-              Preview Document
+              {t("courseForm.previewButton")}
             </Button>
           )}
 
@@ -259,10 +261,10 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
             {isUploading ? (
               <>
                 <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                Uploading...
+                {t("common.actions.uploading")}
               </>
             ) : (
-              "Add Course"
+              t("content.addCourse")
             )}
           </Button>
         </form>

--- a/Ascenda Padrinho att/src/components/content/YouTubePreview.jsx
+++ b/Ascenda Padrinho att/src/components/content/YouTubePreview.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { extractYouTubeId, getYouTubeThumbnail } from "../utils/youtube";
 import { AlertCircle, Youtube } from "lucide-react";
+import { useTranslation } from "@/i18n";
 
 export default function YouTubePreview({ url, onVideoIdChange }) {
   const [videoId, setVideoId] = useState(null);
   const [error, setError] = useState(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!url) {
@@ -35,7 +37,7 @@ export default function YouTubePreview({ url, onVideoIdChange }) {
     return (
       <div className="mt-2 p-3 bg-error/10 border border-error/30 rounded-lg flex items-center gap-2">
         <AlertCircle className="w-4 h-4 text-error" />
-        <span className="text-sm text-error">Invalid YouTube URL. Please check the link.</span>
+        <span className="text-sm text-error">{t("youtube.invalid")}</span>
       </div>
     );
   }
@@ -45,19 +47,23 @@ export default function YouTubePreview({ url, onVideoIdChange }) {
       <div className="mt-3 space-y-2">
         <div className="flex items-center gap-2 text-success">
           <Youtube className="w-4 h-4" />
-          <span className="text-sm font-medium">YouTube Video Detected</span>
+          <span className="text-sm font-medium">{t("youtube.detected")}</span>
         </div>
         <div className="relative rounded-lg overflow-hidden border border-border bg-black">
-          <img 
-            src={getYouTubeThumbnail(videoId)} 
-            alt="Video thumbnail"
+          <img
+            src={getYouTubeThumbnail(videoId)}
+            alt={t("youtube.thumbnailAlt")}
             className="w-full h-32 object-cover"
           />
-          <div className="absolute inset-0 flex items-center justify-center bg-black/30">
+          <div
+            className="absolute inset-0 flex items-center justify-center bg-black/30"
+            aria-hidden="true"
+          >
             <div className="w-12 h-12 bg-error rounded-full flex items-center justify-center">
               <Youtube className="w-6 h-6 text-white" />
             </div>
           </div>
+          <span className="sr-only">{t("youtube.playOverlay")}</span>
         </div>
       </div>
     );

--- a/Ascenda Padrinho att/src/components/courses/AssignCourseModal.jsx
+++ b/Ascenda Padrinho att/src/components/courses/AssignCourseModal.jsx
@@ -12,6 +12,7 @@ import { User } from "@/entities/User";
 import { Loader2, UserPlus, Calendar } from "lucide-react";
 import Avatar from "../ui/Avatar";
 import { eventBus, EventTypes } from "../utils/eventBus";
+import { useTranslation } from "@/i18n";
 
 export default function AssignCourseModal({ course, isOpen, onClose, onSuccess }) {
   const [interns, setInterns] = useState([]);
@@ -20,6 +21,7 @@ export default function AssignCourseModal({ course, isOpen, onClose, onSuccess }
   const [notes, setNotes] = useState("");
   const [isAssigning, setIsAssigning] = useState(false);
   const [user, setUser] = useState(null);
+  const { t } = useTranslation();
 
   useEffect(() => {
     const loadData = async () => {
@@ -107,16 +109,16 @@ export default function AssignCourseModal({ course, isOpen, onClose, onSuccess }
         <DialogHeader>
           <DialogTitle className="text-primary flex items-center gap-2">
             <UserPlus className="w-5 h-5 text-brand" />
-            Assign "{course.title}" to Interns
+            {t("assignModal.title", { course: course.title })}
           </DialogTitle>
         </DialogHeader>
 
         <form onSubmit={handleAssign} className="space-y-6">
           <div>
-            <Label className="text-secondary mb-3 block">Select Interns *</Label>
+            <Label className="text-secondary mb-3 block">{t("assignModal.selectInterns")}</Label>
             <div className="space-y-2 max-h-64 overflow-y-auto border border-border rounded-lg p-3 bg-surface2">
               {interns.length === 0 ? (
-                <p className="text-muted text-sm text-center py-4">No active interns available</p>
+                <p className="text-muted text-sm text-center py-4">{t("assignModal.noneAvailable")}</p>
               ) : (
                 interns.map(intern => (
                   <label
@@ -138,14 +140,14 @@ export default function AssignCourseModal({ course, isOpen, onClose, onSuccess }
               )}
             </div>
             <p className="text-xs text-muted mt-2">
-              {selectedInterns.size} intern{selectedInterns.size !== 1 ? 's' : ''} selected
+              {t("assignModal.selectedCount", { count: selectedInterns.size })}
             </p>
           </div>
 
           <div>
             <Label htmlFor="due-date" className="text-secondary flex items-center gap-2">
               <Calendar className="w-4 h-4" />
-              Due Date (Optional)
+              {t("assignModal.dueDate")}
             </Label>
             <Input
               id="due-date"
@@ -158,12 +160,12 @@ export default function AssignCourseModal({ course, isOpen, onClose, onSuccess }
           </div>
 
           <div>
-            <Label htmlFor="notes" className="text-secondary">Notes (Optional)</Label>
+            <Label htmlFor="notes" className="text-secondary">{t("assignModal.notes")}</Label>
             <Textarea
               id="notes"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              placeholder="Add any special instructions or context..."
+              placeholder={t("common.placeholders.notes")}
               className="bg-surface2 border-border text-primary h-24"
             />
           </div>
@@ -175,7 +177,7 @@ export default function AssignCourseModal({ course, isOpen, onClose, onSuccess }
               onClick={onClose}
               className="border-border"
             >
-              Cancel
+              {t("common.actions.cancel")}
             </Button>
             <Button
               type="submit"
@@ -185,10 +187,10 @@ export default function AssignCourseModal({ course, isOpen, onClose, onSuccess }
               {isAssigning ? (
                 <>
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  Assigning...
+                  {t("assignModal.assigning")}
                 </>
               ) : (
-                `Assign to ${selectedInterns.size} Intern${selectedInterns.size !== 1 ? 's' : ''}`
+                t("assignModal.assignTo", { count: selectedInterns.size })
               )}
             </Button>
           </DialogFooter>

--- a/Ascenda Padrinho att/src/components/dashboard/InternCard.jsx
+++ b/Ascenda Padrinho att/src/components/dashboard/InternCard.jsx
@@ -7,8 +7,10 @@ import { motion } from "framer-motion";
 import { LineChart, Line, ResponsiveContainer } from "recharts";
 import Avatar from "../ui/Avatar";
 import { getDaysLeft, getDaysLeftBadgeColor } from "../utils/dates";
+import { useTranslation } from "@/i18n";
 
 export default function InternCard({ intern, onClick, onChatClick, index }) {
+  const { t } = useTranslation();
   const avgScore = intern.performance_history?.length > 0
     ? intern.performance_history.reduce((sum, p) => sum + p.score, 0) / intern.performance_history.length
     : 0;
@@ -28,6 +30,13 @@ export default function InternCard({ intern, onClick, onChatClick, index }) {
 
   const daysLeft = intern.end_date ? getDaysLeft(intern.end_date) : null;
   const daysLeftColors = daysLeft !== null ? getDaysLeftBadgeColor(daysLeft) : null;
+  const levelLabels = React.useMemo(() => ({
+    "Novice": t("internsPage.levels.novice"),
+    "Apprentice": t("internsPage.levels.apprentice"),
+    "Journeyman": t("internsPage.levels.journeyman"),
+    "Expert": t("internsPage.levels.expert"),
+    "Master": t("internsPage.levels.master"),
+  }), [t]);
 
   const handleChatClick = (e) => {
     e.stopPropagation();
@@ -70,20 +79,20 @@ export default function InternCard({ intern, onClick, onChatClick, index }) {
                 </h3>
                 <div className="flex items-center gap-2 mt-1 flex-wrap">
                   <Badge className={`${levelColors[intern.level]} border`}>
-                    {intern.level}
+                    {levelLabels[intern.level] || intern.level}
                   </Badge>
                   {daysLeft !== null && daysLeftColors && (
                     <Badge className={`${daysLeftColors.bg} ${daysLeftColors.text} border ${daysLeftColors.border}`}>
                       <Calendar className="w-3 h-3 mr-1" />
-                      {daysLeft}d left
+                      {t("internCard.daysLeftShort", { count: daysLeft })}
                     </Badge>
                   )}
                 </div>
               </div>
-              
+
               <div className="flex items-center gap-4 text-sm">
                 <div className="flex items-center gap-1">
-                  <span className="text-muted">Points:</span>
+                  <span className="text-muted">{t("internCard.points")}</span>
                   <span className="font-bold text-brand2">
                     {intern.points}
                   </span>
@@ -92,7 +101,7 @@ export default function InternCard({ intern, onClick, onChatClick, index }) {
                   <div className="flex items-center gap-1">
                     <TrendingUp className="w-4 h-4 text-success" />
                     <span className="text-success font-medium">
-                      {avgScore.toFixed(0)}% avg
+                      {t("internCard.average", { value: avgScore.toFixed(0) })}
                     </span>
                   </div>
                 )}
@@ -135,7 +144,7 @@ export default function InternCard({ intern, onClick, onChatClick, index }) {
                 className="w-full mt-2 border-border hover:bg-surface2 text-secondary hover:text-primary"
               >
                 <MessageCircle className="w-4 h-4 mr-2" />
-                Chat
+                {t("internCard.chat")}
               </Button>
             </div>
           </div>

--- a/Ascenda Padrinho att/src/components/dashboard/InternStatusCard.jsx
+++ b/Ascenda Padrinho att/src/components/dashboard/InternStatusCard.jsx
@@ -8,6 +8,7 @@ import { motion } from "framer-motion";
 import { RadialBarChart, RadialBar, ResponsiveContainer } from "recharts";
 import Avatar from "../ui/Avatar";
 import { getDaysLeft, getDaysLeftBadgeColor, getInternshipProgress } from "../utils/dates";
+import { useTranslation } from "@/i18n";
 
 const wellBeingVariants = {
   "Excellent": { icon: Smile, color: "text-success", bg: "bg-success/10" },
@@ -29,6 +30,7 @@ const wellBeingAliases = {
 };
 
 export default function InternStatusCard({ intern, onStatusToggle, index }) {
+  const { t } = useTranslation();
   const rawStatus = intern.well_being_status;
   const normalizedStatus = typeof rawStatus === "string"
     ? rawStatus.trim().toLowerCase()
@@ -40,11 +42,21 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
   const wellBeing = wellBeingVariants[canonicalStatus] || wellBeingVariants["Neutral"];
   const WellBeingIcon = wellBeing.icon;
   const isActive = intern.status === 'active';
-  
+  const wellBeingLabels = {
+    "Excellent": t("internStatus.labels.excellent", { defaultValue: "Excellent" }),
+    "Good": t("internStatus.labels.good", { defaultValue: "Good" }),
+    "Neutral": t("internStatus.labels.neutral", { defaultValue: "Neutral" }),
+    "Stressed": t("internStatus.labels.stressed", { defaultValue: "Stressed" }),
+    "Overwhelmed": t("internStatus.labels.overwhelmed", { defaultValue: "Overwhelmed" }),
+  };
+  const displayStatus = canonicalStatus
+    ? wellBeingLabels[canonicalStatus] || canonicalStatus
+    : intern.well_being_status || t("common.misc.unknown");
+
   const daysLeft = intern.end_date ? getDaysLeft(intern.end_date) : null;
   const daysLeftColors = daysLeft !== null ? getDaysLeftBadgeColor(daysLeft) : null;
-  const progress = intern.start_date && intern.end_date 
-    ? getInternshipProgress(intern.start_date, intern.end_date) 
+  const progress = intern.start_date && intern.end_date
+    ? getInternshipProgress(intern.start_date, intern.end_date)
     : 0;
 
   const radialData = React.useMemo(() => [{
@@ -88,7 +100,9 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
                   {intern.well_being_status && (
                     <div
                       className={`p-1.5 rounded-lg ${wellBeing.bg}`}
-                      title={`Well-being: ${canonicalStatus || intern.well_being_status || 'Unknown'}`}
+                      title={t("internStatus.tooltip", {
+                        status: displayStatus,
+                      })}
                     >
                       <WellBeingIcon className={`w-4 h-4 ${wellBeing.color}`} />
                     </div>
@@ -96,7 +110,7 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
                 </div>
                 <div className="flex items-center gap-2 text-sm flex-wrap">
                   <Badge variant="outline" className="bg-surface2 text-secondary border-border">
-                    {intern.track || 'Learning Track'}
+                    {intern.track || t("internStatus.trackFallback")}
                   </Badge>
                   <span className="text-muted">•</span>
                   <span className="text-muted">{intern.level}</span>
@@ -107,8 +121,8 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
                 <div className="flex items-center gap-3">
                   <div className="w-12 h-12">
                     <ResponsiveContainer width="100%" height="100%">
-                      <RadialBarChart 
-                        data={radialData} 
+                      <RadialBarChart
+                        data={radialData}
                         startAngle={90} 
                         endAngle={-270}
                         innerRadius="70%"
@@ -123,10 +137,10 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
                     </ResponsiveContainer>
                   </div>
                   <div className="flex-1">
-                    <p className="text-xs text-muted mb-1">Internship Progress</p>
+                    <p className="text-xs text-muted mb-1">{t("internStatus.internshipProgress")}</p>
                     <Badge className={`${daysLeftColors.bg} ${daysLeftColors.text} border ${daysLeftColors.border}`}>
                       <Calendar className="w-3 h-3 mr-1" />
-                      {daysLeft} days left
+                      {t("internStatus.daysLeft", { count: daysLeft })}
                     </Badge>
                   </div>
                 </div>
@@ -134,11 +148,11 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
 
               <div className="flex items-center justify-between pt-2 border-t border-border">
                 <Label htmlFor={`status-${intern.id}`} className="text-sm text-secondary cursor-pointer">
-                  System Status
+                  {t("internStatus.systemStatus")}
                 </Label>
                 <div className="flex items-center gap-2">
                   <span className={`text-sm font-medium ${isActive ? 'text-success' : 'text-warning'}`}>
-                    {isActive ? 'Active' : 'Paused'}
+                    {isActive ? t("common.status.active") : t("common.status.paused")}
                   </span>
                   <Switch
                     id={`status-${intern.id}`}

--- a/Ascenda Padrinho att/src/components/dashboard/PerformanceChart.jsx
+++ b/Ascenda Padrinho att/src/components/dashboard/PerformanceChart.jsx
@@ -1,11 +1,40 @@
 import React from "react";
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { useLanguage, useTranslation } from "@/i18n";
 
 export default function PerformanceChart({ data }) {
+  const { t } = useTranslation();
+  const { language } = useLanguage();
+
+  const percentFormatter = React.useMemo(
+    () =>
+      new Intl.NumberFormat(language === "pt" ? "pt-BR" : "en-US", {
+        maximumFractionDigits: 0,
+      }),
+    [language]
+  );
+
+  const tooltipValue = React.useCallback(
+    (value) =>
+      t("dashboard.performanceChart.tooltipValue", {
+        value: percentFormatter.format(value),
+      }),
+    [percentFormatter, t]
+  );
+
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-muted">
-        <p>No performance data available</p>
+        <p>{t("dashboard.performanceChart.noData")}</p>
       </div>
     );
   }
@@ -15,44 +44,57 @@ export default function PerformanceChart({ data }) {
       <AreaChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
         <defs>
           <linearGradient id="colorScore" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor="var(--brand)" stopOpacity={0.3}/>
-            <stop offset="95%" stopColor="var(--brand)" stopOpacity={0}/>
+            <stop offset="5%" stopColor="var(--brand)" stopOpacity={0.3} />
+            <stop offset="95%" stopColor="var(--brand)" stopOpacity={0} />
           </linearGradient>
         </defs>
         <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" opacity={0.3} />
-        <XAxis 
-          dataKey="month" 
-          stroke="var(--text-muted)" 
-          tick={{ fill: 'var(--text-muted)' }}
-          style={{ fontSize: '12px' }}
+        <XAxis
+          dataKey="month"
+          stroke="var(--text-muted)"
+          tick={{ fill: "var(--text-muted)" }}
+          style={{ fontSize: "12px" }}
         />
-        <YAxis 
-          stroke="var(--text-muted)" 
-          tick={{ fill: 'var(--text-muted)' }}
-          style={{ fontSize: '12px' }}
+        <YAxis
+          stroke="var(--text-muted)"
+          tick={{ fill: "var(--text-muted)" }}
+          style={{ fontSize: "12px" }}
           domain={[0, 100]}
+          tickFormatter={(value) =>
+            t("dashboard.performanceChart.percentValue", {
+              value: percentFormatter.format(value),
+            })
+          }
         />
-        <Tooltip 
-          contentStyle={{ 
-            backgroundColor: 'var(--surface)',
-            border: '1px solid var(--border)',
-            borderRadius: '8px',
-            color: 'var(--text-primary)'
+        <Tooltip
+          contentStyle={{
+            backgroundColor: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: "8px",
+            color: "var(--text-primary)",
           }}
-          labelStyle={{ color: 'var(--text-secondary)' }}
+          labelStyle={{ color: "var(--text-secondary)" }}
+          formatter={(value) => [
+            tooltipValue(value),
+            t("dashboard.performanceChart.legendLabel"),
+          ]}
+          labelFormatter={(label) =>
+            t("dashboard.performanceChart.tooltipLabel", { label })
+          }
         />
-        <Legend 
-          wrapperStyle={{ color: 'var(--text-secondary)' }}
+        <Legend
+          wrapperStyle={{ color: "var(--text-secondary)" }}
           iconType="line"
+          formatter={() => t("dashboard.performanceChart.legendLabel")}
         />
-        <Area 
-          type="monotone" 
-          dataKey="score" 
-          stroke="var(--brand)" 
+        <Area
+          type="monotone"
+          dataKey="score"
+          stroke="var(--brand)"
           strokeWidth={2}
-          fill="url(#colorScore)" 
-          name="Performance Score"
-          dot={{ fill: 'var(--brand)', r: 4 }}
+          fill="url(#colorScore)"
+          name={t("dashboard.performanceChart.legendLabel")}
+          dot={{ fill: "var(--brand)", r: 4 }}
           activeDot={{ r: 6 }}
         />
       </AreaChart>

--- a/Ascenda Padrinho att/src/components/interns/ActiveAssignments.jsx
+++ b/Ascenda Padrinho att/src/components/interns/ActiveAssignments.jsx
@@ -8,11 +8,13 @@ import { Course } from "@/entities/Course";
 import { BookOpen, Calendar, Clock, CheckCircle2, PlayCircle, Loader2 } from "lucide-react";
 import { format } from "date-fns";
 import { motion } from "framer-motion";
+import { useTranslation } from "@/i18n";
 
 export default function ActiveAssignments({ internId }) {
   const [assignments, setAssignments] = useState([]);
   const [courses, setCourses] = useState({});
   const [loading, setLoading] = useState(true);
+  const { t } = useTranslation();
 
   useEffect(() => {
     const loadAssignments = async () => {
@@ -63,7 +65,7 @@ export default function ActiveAssignments({ internId }) {
     return (
       <Card className="border-border bg-surface shadow-e1">
         <CardHeader>
-          <CardTitle className="text-primary">Active Course Assignments</CardTitle>
+          <CardTitle className="text-primary">{t("assignments.title")}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex items-center justify-center py-8">
@@ -78,10 +80,10 @@ export default function ActiveAssignments({ internId }) {
     return (
       <Card className="border-border bg-surface shadow-e1">
         <CardHeader>
-          <CardTitle className="text-primary">Active Course Assignments</CardTitle>
+          <CardTitle className="text-primary">{t("assignments.title")}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-muted text-center py-8">No active course assignments</p>
+          <p className="text-muted text-center py-8">{t("assignments.none")}</p>
         </CardContent>
       </Card>
     );
@@ -93,13 +95,13 @@ export default function ActiveAssignments({ internId }) {
   };
 
   return (
-    <Card className="border-border bg-surface shadow-e1">
-      <CardHeader>
-        <CardTitle className="text-primary flex items-center gap-2">
-          <BookOpen className="w-5 h-5" />
-          Active Course Assignments ({assignments.length})
-        </CardTitle>
-      </CardHeader>
+      <Card className="border-border bg-surface shadow-e1">
+        <CardHeader>
+          <CardTitle className="text-primary flex items-center gap-2">
+            <BookOpen className="w-5 h-5" />
+            {t("common.counts.assignments", { count: assignments.length })}
+          </CardTitle>
+        </CardHeader>
       <CardContent>
         <div className="space-y-4">
           {assignments.map((assignment, index) => {
@@ -123,14 +125,16 @@ export default function ActiveAssignments({ internId }) {
                     <p className="text-sm text-muted line-clamp-2">{course.description}</p>
                   </div>
                   <Badge className={`${colors.bg} ${colors.text} border ${colors.border} shrink-0`}>
-                    {assignment.status === 'assigned' ? 'Assigned' : 'In Progress'}
+                    {assignment.status === 'assigned'
+                      ? t("assignments.assigned")
+                      : t("assignments.inProgress")}
                   </Badge>
                 </div>
 
                 {assignment.progress > 0 && (
                   <div className="mb-3">
                     <div className="flex items-center justify-between text-xs text-muted mb-1">
-                      <span>Progress</span>
+                      <span>{t("assignments.progress")}</span>
                       <span>{assignment.progress}%</span>
                     </div>
                     <Progress value={assignment.progress} className="h-2" />
@@ -147,13 +151,13 @@ export default function ActiveAssignments({ internId }) {
                   {assignment.assigned_date && (
                     <div className="flex items-center gap-1">
                       <Calendar className="w-3 h-3" />
-                      <span>Assigned {format(new Date(assignment.assigned_date), 'MMM d')}</span>
+                      <span>{t("assignments.assignedOn", { date: format(new Date(assignment.assigned_date), 'MMM d') })}</span>
                     </div>
                   )}
                   {assignment.due_date && (
                     <div className="flex items-center gap-1">
                       <Calendar className="w-3 h-3 text-error" />
-                      <span className="text-error">Due {format(new Date(assignment.due_date), 'MMM d')}</span>
+                      <span className="text-error">{t("assignments.dueOn", { date: format(new Date(assignment.due_date), 'MMM d') })}</span>
                     </div>
                   )}
                 </div>
@@ -171,7 +175,7 @@ export default function ActiveAssignments({ internId }) {
                     className="w-full bg-brand hover:bg-brand/90 text-white"
                   >
                     <PlayCircle className="w-4 h-4 mr-2" />
-                    Start Course
+                    {t("assignments.startCourse")}
                   </Button>
                 )}
 
@@ -183,7 +187,7 @@ export default function ActiveAssignments({ internId }) {
                     className="w-full border-success hover:bg-success/10 text-success"
                   >
                     <CheckCircle2 className="w-4 h-4 mr-2" />
-                    Mark as Completed
+                    {t("assignments.markCompleted")}
                   </Button>
                 )}
               </motion.div>

--- a/Ascenda Padrinho att/src/components/interns/InternDetailModal.jsx
+++ b/Ascenda Padrinho att/src/components/interns/InternDetailModal.jsx
@@ -9,9 +9,18 @@ import Avatar from "../ui/Avatar";
 import { Calendar, Trophy, Target, CalendarCheck } from "lucide-react";
 import { format } from "date-fns";
 import { getDaysLeft, getDaysLeftBadgeColor } from "../utils/dates";
+import { useTranslation } from "@/i18n";
 
 export default function InternDetailModal({ intern, isOpen, onClose }) {
   const [tasks, setTasks] = React.useState([]);
+  const { t } = useTranslation();
+  const levelLabels = React.useMemo(() => ({
+    "Novice": t("internsPage.levels.novice"),
+    "Apprentice": t("internsPage.levels.apprentice"),
+    "Journeyman": t("internsPage.levels.journeyman"),
+    "Expert": t("internsPage.levels.expert"),
+    "Master": t("internsPage.levels.master"),
+  }), [t]);
 
   React.useEffect(() => {
     const loadTasks = async () => {
@@ -39,7 +48,7 @@ export default function InternDetailModal({ intern, isOpen, onClose }) {
           <DialogTitle className="flex items-center gap-4">
             <div className="w-16 h-16 rounded-full bg-gradient-to-br from-brand to-brand2 p-0.5 shrink-0">
               <div className="w-full h-full rounded-full bg-surface flex items-center justify-center overflow-hidden">
-                <Avatar 
+                <Avatar
                   src={intern.avatar_url} 
                   alt={intern.full_name}
                   size={60}
@@ -48,14 +57,14 @@ export default function InternDetailModal({ intern, isOpen, onClose }) {
             </div>
             <div className="min-w-0">
               <h2 className="text-2xl font-bold text-primary truncate">{intern.full_name}</h2>
-              <div className="flex items-center gap-2 mt-1 flex-wrap">
-                <Badge className="bg-surface2 text-secondary border-border">
-                  {intern.level}
-                </Badge>
-                <Badge variant="outline" className="text-muted">
-                  {intern.track}
-                </Badge>
-              </div>
+                <div className="flex items-center gap-2 mt-1 flex-wrap">
+                  <Badge className="bg-surface2 text-secondary border-border">
+                    {levelLabels[intern.level] || intern.level}
+                  </Badge>
+                  <Badge variant="outline" className="text-muted">
+                    {intern.track}
+                  </Badge>
+                </div>
             </div>
           </DialogTitle>
         </DialogHeader>
@@ -65,7 +74,7 @@ export default function InternDetailModal({ intern, isOpen, onClose }) {
             <div className="bg-surface2 border border-border rounded-xl p-4">
               <div className="flex items-center gap-2 mb-2">
                 <Trophy className="w-5 h-5 text-brand2" />
-                <span className="text-sm text-muted">Total Points</span>
+                <span className="text-sm text-muted">{t("internDetails.totalPoints")}</span>
               </div>
               <p className="text-2xl font-bold text-brand2">
                 {intern.points}
@@ -75,7 +84,7 @@ export default function InternDetailModal({ intern, isOpen, onClose }) {
             <div className="bg-surface2 border border-border rounded-xl p-4">
               <div className="flex items-center gap-2 mb-2">
                 <Target className="w-5 h-5 text-success" />
-                <span className="text-sm text-muted">Tasks Done</span>
+                <span className="text-sm text-muted">{t("internDetails.tasksDone")}</span>
               </div>
               <p className="text-2xl font-bold text-primary">
                 {completedTasks}/{tasks.length}
@@ -85,7 +94,7 @@ export default function InternDetailModal({ intern, isOpen, onClose }) {
             <div className="bg-surface2 border border-border rounded-xl p-4">
               <div className="flex items-center gap-2 mb-2">
                 <Calendar className="w-5 h-5 text-brand" />
-                <span className="text-sm text-muted">Start Date</span>
+                <span className="text-sm text-muted">{t("internDetails.startDate")}</span>
               </div>
               <p className="text-lg font-semibold text-primary">
                 {intern.start_date ? format(new Date(intern.start_date), 'MMM d, yyyy') : 'N/A'}
@@ -95,7 +104,7 @@ export default function InternDetailModal({ intern, isOpen, onClose }) {
             <div className="bg-surface2 border border-border rounded-xl p-4">
               <div className="flex items-center gap-2 mb-2">
                 <CalendarCheck className="w-5 h-5 text-warning" />
-                <span className="text-sm text-muted">End Date</span>
+                <span className="text-sm text-muted">{t("internDetails.endDate")}</span>
               </div>
               <div>
                 <p className="text-lg font-semibold text-primary mb-1">
@@ -103,7 +112,7 @@ export default function InternDetailModal({ intern, isOpen, onClose }) {
                 </p>
                 {daysLeft !== null && daysLeftColors && (
                   <Badge className={`${daysLeftColors.bg} ${daysLeftColors.text} border ${daysLeftColors.border} text-xs`}>
-                    {daysLeft} days left
+                    {t("internDetails.daysLeft", { count: daysLeft })}
                   </Badge>
                 )}
               </div>
@@ -112,19 +121,19 @@ export default function InternDetailModal({ intern, isOpen, onClose }) {
 
           <Tabs defaultValue="performance" className="w-full">
             <TabsList className="grid w-full grid-cols-2 bg-surface2">
-              <TabsTrigger value="performance">Performance</TabsTrigger>
-              <TabsTrigger value="courses">Active Courses</TabsTrigger>
+              <TabsTrigger value="performance">{t("internDetails.tabs.performance")}</TabsTrigger>
+              <TabsTrigger value="courses">{t("internDetails.tabs.courses")}</TabsTrigger>
             </TabsList>
             <TabsContent value="performance" className="space-y-4 mt-4">
               <PerformancePanel intern={intern} />
-              
+
               {intern.skills && intern.skills.length > 0 && (
                 <div>
-                  <h3 className="text-lg font-semibold mb-3 text-primary">Skills</h3>
+                  <h3 className="text-lg font-semibold mb-3 text-primary">{t("internDetails.skills")}</h3>
                   <div className="flex flex-wrap gap-2">
                     {intern.skills.map((skill, idx) => (
-                      <Badge 
-                        key={idx} 
+                      <Badge
+                        key={idx}
                         className="bg-surface2 text-secondary border-border"
                       >
                         {skill}

--- a/Ascenda Padrinho att/src/components/interns/PerformancePanel.jsx
+++ b/Ascenda Padrinho att/src/components/interns/PerformancePanel.jsx
@@ -1,28 +1,29 @@
 import React, { useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { 
-  ComposedChart, 
-  Area, 
-  Line, 
-  Bar, 
-  XAxis, 
-  YAxis, 
-  CartesianGrid, 
-  Tooltip, 
-  Legend, 
+import {
+  ComposedChart,
+  Area,
+  Line,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
   ResponsiveContainer,
   ReferenceLine,
   Brush
 } from "recharts";
 import { Download, TrendingUp, Target, Award, Clock } from "lucide-react";
 import { format } from "date-fns";
+import { useTranslation } from "@/i18n";
 
-function PerfTooltip({ active, payload }) {
+function PerfTooltip({ active, payload, t }) {
   if (!active || !payload || !payload.length) return null;
 
   const data = payload[0].payload;
-  
+
   return (
     <div className="bg-surface border border-border rounded-lg p-3 shadow-e2">
       <p className="text-sm font-semibold text-primary mb-2">
@@ -30,20 +31,20 @@ function PerfTooltip({ active, payload }) {
       </p>
       <div className="space-y-1 text-xs">
         <div className="flex items-center justify-between gap-4">
-          <span className="text-muted">Score:</span>
+          <span className="text-muted">{t("performance.tooltip.score")}</span>
           <span className="font-medium text-primary">{data.score}%</span>
         </div>
         <div className="flex items-center justify-between gap-4">
-          <span className="text-muted">Completion:</span>
+          <span className="text-muted">{t("performance.tooltip.completion")}</span>
           <span className="font-medium text-brand">{data.completion}%</span>
         </div>
         <div className="flex items-center justify-between gap-4">
-          <span className="text-muted">Points:</span>
+          <span className="text-muted">{t("performance.tooltip.points")}</span>
           <span className="font-medium text-brand2">{data.points}</span>
         </div>
         {data.hours && (
           <div className="flex items-center justify-between gap-4">
-            <span className="text-muted">Hours:</span>
+            <span className="text-muted">{t("performance.tooltip.hours")}</span>
             <span className="font-medium text-success">{data.hours}h</span>
           </div>
         )}
@@ -53,6 +54,7 @@ function PerfTooltip({ active, payload }) {
 }
 
 export default function PerformancePanel({ intern }) {
+  const { t } = useTranslation();
   const chartData = useMemo(() => {
     if (!intern.performance_history || intern.performance_history.length === 0) {
       return [];
@@ -124,7 +126,7 @@ export default function PerformancePanel({ intern }) {
     return (
       <Card className="border-border bg-surface">
         <CardContent className="p-6 text-center">
-          <p className="text-muted">No performance data available yet</p>
+          <p className="text-muted">{t("internDetails.noPerformance")}</p>
         </CardContent>
       </Card>
     );
@@ -136,7 +138,7 @@ export default function PerformancePanel({ intern }) {
         <div className="flex items-center justify-between">
           <CardTitle className="text-primary flex items-center gap-2">
             <TrendingUp className="w-5 h-5" />
-            Performance Insights
+            {t("performance.title")}
           </CardTitle>
           <Button
             variant="outline"
@@ -145,7 +147,7 @@ export default function PerformancePanel({ intern }) {
             className="border-border"
           >
             <Download className="w-4 h-4 mr-2" />
-            Export CSV
+            {t("performance.export")}
           </Button>
         </div>
       </CardHeader>
@@ -154,7 +156,7 @@ export default function PerformancePanel({ intern }) {
           <div className="bg-surface2 rounded-xl p-4 border border-border">
             <div className="flex items-center gap-2 mb-2">
               <Target className="w-4 h-4 text-brand" />
-              <span className="text-xs text-muted">Current Score</span>
+              <span className="text-xs text-muted">{t("performance.currentScore")}</span>
             </div>
             <p className="text-2xl font-bold text-primary">{stats.currentScore}%</p>
           </div>
@@ -162,7 +164,7 @@ export default function PerformancePanel({ intern }) {
           <div className="bg-surface2 rounded-xl p-4 border border-border">
             <div className="flex items-center gap-2 mb-2">
               <TrendingUp className="w-4 h-4 text-success" />
-              <span className="text-xs text-muted">3-Mo Avg</span>
+              <span className="text-xs text-muted">{t("performance.average")}</span>
             </div>
             <p className="text-2xl font-bold text-primary">{stats.avgScore}%</p>
           </div>
@@ -170,7 +172,7 @@ export default function PerformancePanel({ intern }) {
           <div className="bg-surface2 rounded-xl p-4 border border-border">
             <div className="flex items-center gap-2 mb-2">
               <Award className="w-4 h-4 text-brand2" />
-              <span className="text-xs text-muted">Completed</span>
+              <span className="text-xs text-muted">{t("performance.completed")}</span>
             </div>
             <p className="text-2xl font-bold text-primary">{stats.completedCourses}</p>
           </div>
@@ -178,7 +180,7 @@ export default function PerformancePanel({ intern }) {
           <div className="bg-surface2 rounded-xl p-4 border border-border">
             <div className="flex items-center gap-2 mb-2">
               <Clock className="w-4 h-4 text-warning" />
-              <span className="text-xs text-muted">Study Hours</span>
+              <span className="text-xs text-muted">{t("performance.studyHours")}</span>
             </div>
             <p className="text-2xl font-bold text-primary">{stats.totalHours}h</p>
           </div>
@@ -203,48 +205,48 @@ export default function PerformancePanel({ intern }) {
                 tickFormatter={(value) => format(value, 'MMM')}
               />
               
-              <YAxis 
+              <YAxis
                 yAxisId="left"
                 stroke="var(--text-muted)"
                 tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
                 domain={[0, 100]}
-                label={{ value: 'Score %', angle: -90, position: 'insideLeft', fill: 'var(--text-muted)' }}
+                label={{ value: t("performance.scoreSeries"), angle: -90, position: 'insideLeft', fill: 'var(--text-muted)' }}
               />
-              
-              <YAxis 
+
+              <YAxis
                 yAxisId="right"
                 orientation="right"
                 stroke="var(--text-muted)"
                 tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
-                label={{ value: 'Points', angle: 90, position: 'insideRight', fill: 'var(--text-muted)' }}
+                label={{ value: t("performance.pointsSeries"), angle: 90, position: 'insideRight', fill: 'var(--text-muted)' }}
               />
-              
-              <Tooltip content={<PerfTooltip />} />
-              
-              <Legend 
+
+              <Tooltip content={<PerfTooltip t={t} />} />
+
+              <Legend
                 wrapperStyle={{ paddingTop: '20px' }}
                 iconType="line"
               />
-              
-              <ReferenceLine 
-                yAxisId="left" 
-                y={85} 
-                stroke="var(--success)" 
+
+              <ReferenceLine
+                yAxisId="left"
+                y={85}
+                stroke="var(--success)"
                 strokeDasharray="4 4"
-                label={{ value: 'Target 85%', fill: 'var(--success)', fontSize: 12 }}
+                label={{ value: t("performance.target"), fill: 'var(--success)', fontSize: 12 }}
               />
-              
-              <Area 
+
+              <Area
                 yAxisId="left"
                 type="monotone"
                 dataKey="completion"
                 fill="url(#completionGradient)"
                 stroke="var(--brand)"
                 strokeWidth={2}
-                name="Completion %"
+                name={t("performance.completionSeries")}
               />
-              
-              <Line 
+
+              <Line
                 yAxisId="left"
                 type="monotone"
                 dataKey="score"
@@ -252,16 +254,16 @@ export default function PerformancePanel({ intern }) {
                 strokeWidth={2}
                 dot={{ fill: 'var(--brand-2)', r: 4 }}
                 activeDot={{ r: 6 }}
-                name="Score %"
+                name={t("performance.scoreSeries")}
               />
-              
-              <Bar 
+
+              <Bar
                 yAxisId="right"
                 dataKey="points"
                 fill="var(--brand-2)"
                 opacity={0.6}
                 barSize={12}
-                name="Points"
+                name={t("performance.pointsSeries")}
               />
               
               <Brush

--- a/Ascenda Padrinho att/src/components/notifications/NotificationCenter.jsx
+++ b/Ascenda Padrinho att/src/components/notifications/NotificationCenter.jsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { CheckCheck, BookOpen, MessageCircle, Calendar, X, Bell } from "lucide-react";
 import { format, isToday, isThisWeek } from "date-fns";
+import { useTranslation } from "@/i18n";
 
 const NotificationIcon = ({ type }) => {
   const icons = {
@@ -20,10 +21,11 @@ const NotificationIcon = ({ type }) => {
 };
 
 function NotificationItem({ notification, onMarkRead }) {
+  const { t } = useTranslation();
   return (
     <div className={`p-4 rounded-xl border transition-all ${
-      notification.read 
-        ? 'border-border bg-surface2 opacity-70' 
+      notification.read
+        ? 'border-border bg-surface2 opacity-70'
         : 'border-brand/30 bg-brand/5'
     }`}>
       <div className="flex items-start gap-3">
@@ -51,7 +53,7 @@ function NotificationItem({ notification, onMarkRead }) {
           )}
           {notification.actor_name && (
             <p className="text-xs text-muted">
-              By {notification.actor_name}
+              {t("notifications.by", { name: notification.actor_name })}
             </p>
           )}
           <p className="text-xs text-muted mt-1">
@@ -63,14 +65,15 @@ function NotificationItem({ notification, onMarkRead }) {
   );
 }
 
-export default function NotificationCenter({ 
-  isOpen, 
-  onClose, 
-  notifications, 
+export default function NotificationCenter({
+  isOpen,
+  onClose,
+  notifications,
   onMarkAllRead,
   onMarkRead,
-  onRefresh 
+  onRefresh
 }) {
+  const { t } = useTranslation();
   const groupedNotifications = React.useMemo(() => {
     const groups = {
       today: [],
@@ -109,7 +112,7 @@ export default function NotificationCenter({
       <SheetContent className="w-full sm:max-w-md bg-surface border-border">
         <SheetHeader className="border-b border-border pb-4">
           <div className="flex items-center justify-between">
-            <SheetTitle className="text-primary">Notifications</SheetTitle>
+            <SheetTitle className="text-primary">{t("notifications.title")}</SheetTitle>
             <Button
               variant="ghost"
               size="sm"
@@ -117,7 +120,7 @@ export default function NotificationCenter({
               className="text-brand hover:text-brand/80"
             >
               <CheckCheck className="w-4 h-4 mr-2" />
-              Mark all read
+              {t("notifications.markAllRead")}
             </Button>
           </div>
         </SheetHeader>
@@ -125,11 +128,11 @@ export default function NotificationCenter({
         <div className="mt-6 space-y-6 overflow-y-auto max-h-[calc(100vh-120px)]">
           {groupedNotifications.today.length > 0 && (
             <div>
-              <h3 className="text-sm font-semibold text-muted mb-3">Today</h3>
+              <h3 className="text-sm font-semibold text-muted mb-3">{t("notifications.today")}</h3>
               <div className="space-y-2">
                 {groupedNotifications.today.map(notif => (
-                  <NotificationItem 
-                    key={notif.id} 
+                  <NotificationItem
+                    key={notif.id}
                     notification={notif}
                     onMarkRead={onMarkRead}
                   />
@@ -140,11 +143,11 @@ export default function NotificationCenter({
 
           {groupedNotifications.thisWeek.length > 0 && (
             <div>
-              <h3 className="text-sm font-semibold text-muted mb-3">This Week</h3>
+              <h3 className="text-sm font-semibold text-muted mb-3">{t("notifications.thisWeek")}</h3>
               <div className="space-y-2">
                 {groupedNotifications.thisWeek.map(notif => (
-                  <NotificationItem 
-                    key={notif.id} 
+                  <NotificationItem
+                    key={notif.id}
                     notification={notif}
                     onMarkRead={onMarkRead}
                   />
@@ -155,11 +158,11 @@ export default function NotificationCenter({
 
           {groupedNotifications.older.length > 0 && (
             <div>
-              <h3 className="text-sm font-semibold text-muted mb-3">Earlier</h3>
+              <h3 className="text-sm font-semibold text-muted mb-3">{t("notifications.earlier")}</h3>
               <div className="space-y-2">
                 {groupedNotifications.older.map(notif => (
-                  <NotificationItem 
-                    key={notif.id} 
+                  <NotificationItem
+                    key={notif.id}
                     notification={notif}
                     onMarkRead={onMarkRead}
                   />
@@ -171,7 +174,7 @@ export default function NotificationCenter({
           {notifications.length === 0 && (
             <div className="text-center py-12">
               <Bell className="w-12 h-12 mx-auto mb-3 text-muted opacity-30" />
-              <p className="text-muted">No notifications yet</p>
+              <p className="text-muted">{t("notifications.none")}</p>
             </div>
           )}
         </div>

--- a/Ascenda Padrinho att/src/components/reports/TaskCompletionChart.jsx
+++ b/Ascenda Padrinho att/src/components/reports/TaskCompletionChart.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from "recharts";
+import { useLanguage, useTranslation } from "@/i18n";
 
 const COLORS = {
   completed: 'var(--success)',
@@ -9,17 +10,52 @@ const COLORS = {
 };
 
 export default function TaskCompletionChart({ data }) {
+  const { t } = useTranslation();
+  const { language } = useLanguage();
+
+  const percentFormatter = React.useMemo(
+    () =>
+      new Intl.NumberFormat(language === "pt" ? "pt-BR" : "en-US", {
+        style: "percent",
+        maximumFractionDigits: 0,
+      }),
+    [language]
+  );
+
+  const taskCountFormatter = React.useMemo(
+    () =>
+      new Intl.NumberFormat(language === "pt" ? "pt-BR" : "en-US", {
+        maximumFractionDigits: 0,
+      }),
+    [language]
+  );
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-muted">
-        <p>No task data available</p>
+        <p>{t("reports.noTaskData")}</p>
       </div>
     );
   }
 
-  const formattedData = data.map(item => ({
+  const statusLabels = {
+    completed: t("common.status.completed"),
+    in_progress: t("common.status.inProgress"),
+    pending: t("common.status.pending"),
+    overdue: t("common.status.overdue"),
+  };
+  const getTaskLabel = React.useCallback(
+    (value) =>
+      t(
+        value === 1
+          ? "reports.taskCompletion.taskSingular"
+          : "reports.taskCompletion.taskPlural"
+      ),
+    [t]
+  );
+
+  const formattedData = data.map((item) => ({
     ...item,
-    displayName: item.name.replace('_', ' ').charAt(0).toUpperCase() + item.name.replace('_', ' ').slice(1)
+    displayName: statusLabels[item.name] || item.name,
   }));
 
   return (
@@ -30,7 +66,12 @@ export default function TaskCompletionChart({ data }) {
           cx="50%"
           cy="50%"
           labelLine={false}
-          label={({ displayName, percent }) => `${displayName}: ${(percent * 100).toFixed(0)}%`}
+          label={({ displayName, percent }) =>
+            t("reports.taskCompletion.label", {
+              status: displayName,
+              percent: percentFormatter.format(percent),
+            })
+          }
           outerRadius={100}
           fill="var(--brand)"
           dataKey="value"
@@ -39,16 +80,20 @@ export default function TaskCompletionChart({ data }) {
             <Cell key={`cell-${index}`} fill={COLORS[entry.name]} />
           ))}
         </Pie>
-        <Tooltip 
-          contentStyle={{ 
-            backgroundColor: 'var(--surface)',
-            border: '1px solid var(--border)',
-            borderRadius: '8px',
-            color: 'var(--text-primary)'
+        <Tooltip
+          contentStyle={{
+            backgroundColor: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: "8px",
+            color: "var(--text-primary)",
           }}
+          formatter={(value, name, entry) => [
+            `${taskCountFormatter.format(value)} ${getTaskLabel(value)}`,
+            statusLabels[entry.payload.name] || entry.payload.displayName,
+          ]}
         />
-        <Legend 
-          wrapperStyle={{ color: 'var(--text-secondary)' }}
+        <Legend
+          wrapperStyle={{ color: "var(--text-secondary)" }}
           formatter={(value, entry) => entry.payload.displayName}
         />
       </PieChart>

--- a/Ascenda Padrinho att/src/components/reports/TeamPerformanceChart.jsx
+++ b/Ascenda Padrinho att/src/components/reports/TeamPerformanceChart.jsx
@@ -1,11 +1,38 @@
 import React from "react";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { useLanguage, useTranslation } from "@/i18n";
 
 export default function TeamPerformanceChart({ data }) {
+  const { t } = useTranslation();
+  const { language } = useLanguage();
+
+  const numberFormatter = React.useMemo(
+    () => new Intl.NumberFormat(language === "pt" ? "pt-BR" : "en-US"),
+    [language]
+  );
+
+  const pointsLabel = React.useCallback(
+    (value) =>
+      t(
+        value === 1
+          ? "reports.teamPerformancePoints.singular"
+          : "reports.teamPerformancePoints.plural"
+      ),
+    [t]
+  );
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-muted">
-        <p>No performance data available</p>
+        <p>{t("internDetails.noPerformance")}</p>
       </div>
     );
   }
@@ -20,13 +47,14 @@ export default function TeamPerformanceChart({ data }) {
           tick={{ fill: 'var(--text-muted)' }}
           style={{ fontSize: '12px' }}
         />
-        <YAxis 
-          stroke="var(--text-muted)" 
+        <YAxis
+          stroke="var(--text-muted)"
           tick={{ fill: 'var(--text-muted)' }}
           style={{ fontSize: '12px' }}
+          tickFormatter={(value) => numberFormatter.format(value)}
         />
-        <Tooltip 
-          contentStyle={{ 
+        <Tooltip
+          contentStyle={{
             backgroundColor: 'var(--surface)',
             border: '1px solid var(--border)',
             borderRadius: '8px',
@@ -34,15 +62,20 @@ export default function TeamPerformanceChart({ data }) {
           }}
           labelStyle={{ color: 'var(--text-secondary)' }}
           cursor={{ fill: 'var(--surface-2)', opacity: 0.3 }}
+          formatter={(value) => [
+            `${numberFormatter.format(value)} ${pointsLabel(value)}`,
+            t("performance.pointsSeries"),
+          ]}
         />
-        <Legend 
+        <Legend
           wrapperStyle={{ color: 'var(--text-secondary)' }}
+          formatter={() => t("performance.pointsSeries")}
         />
-        <Bar 
-          dataKey="points" 
-          fill="var(--brand)" 
+        <Bar
+          dataKey="points"
+          fill="var(--brand)"
           radius={[8, 8, 0, 0]}
-          name="Points"
+          name={t("performance.pointsSeries")}
         />
       </BarChart>
     </ResponsiveContainer>

--- a/Ascenda Padrinho att/src/components/theme/LanguageToggle.jsx
+++ b/Ascenda Padrinho att/src/components/theme/LanguageToggle.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Languages } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useLanguage, useTranslation } from "@/i18n";
+
+export default function LanguageToggle() {
+  const { language, toggleLanguage } = useLanguage();
+  const { t } = useTranslation();
+
+  const nextLanguage = language === "en" ? "pt" : "en";
+  const currentLabel = language === "en" ? t("layout.languageToggle.english") : t("layout.languageToggle.portuguese");
+  const nextLabel = nextLanguage === "en" ? t("layout.languageToggle.english") : t("layout.languageToggle.portuguese");
+
+  const handleClick = React.useCallback(() => {
+    toggleLanguage();
+  }, [toggleLanguage]);
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={handleClick}
+      className="flex items-center gap-2 border-border bg-surface hover:bg-surface2"
+      aria-label={`${t("layout.languageToggle.label")}: ${currentLabel}`}
+    >
+      <Languages className="w-4 h-4" />
+      <span className="text-sm font-medium text-primary">
+        {currentLabel}
+      </span>
+      <span className="text-xs text-muted">/ {nextLabel}</span>
+    </Button>
+  );
+}

--- a/Ascenda Padrinho att/src/components/vacation/VacationCalendar.jsx
+++ b/Ascenda Padrinho att/src/components/vacation/VacationCalendar.jsx
@@ -5,10 +5,12 @@ import { Card, CardContent } from "@/components/ui/card";
 import { ChevronLeft, ChevronRight, AlertTriangle } from "lucide-react";
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameMonth, isToday, isWithinInterval, addMonths, subMonths, startOfWeek, endOfWeek, isSameDay } from "date-fns";
 import { Task } from "@/entities/Task";
+import { useTranslation } from "@/i18n";
 
 export default function VacationCalendar({ requests, interns }) {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [tasks, setTasks] = useState([]);
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     const loadTasks = async () => {
@@ -119,7 +121,7 @@ export default function VacationCalendar({ requests, interns }) {
             size="sm"
             onClick={handlePrevMonth}
             className="border-border"
-            aria-label="Previous month"
+            aria-label={t("vacation.calendar.previousMonth")}
           >
             <ChevronLeft className="w-4 h-4" />
           </Button>
@@ -129,14 +131,14 @@ export default function VacationCalendar({ requests, interns }) {
             onClick={() => setCurrentDate(new Date())}
             className="border-border"
           >
-            Today
+            {t("vacation.calendar.buttonToday")}
           </Button>
           <Button
             variant="outline"
             size="sm"
             onClick={handleNextMonth}
             className="border-border"
-            aria-label="Next month"
+            aria-label={t("vacation.calendar.nextMonth")}
           >
             <ChevronRight className="w-4 h-4" />
           </Button>
@@ -150,17 +152,20 @@ export default function VacationCalendar({ requests, interns }) {
               <AlertTriangle className="w-5 h-5 text-error flex-shrink-0 mt-0.5" />
               <div className="flex-1">
                 <h4 className="font-semibold text-error mb-2">
-                  {conflicts.length} Scheduling Conflict{conflicts.length !== 1 ? 's' : ''} Detected
+                  {t("vacation.calendar.months.conflict", { count: conflicts.length })}
                 </h4>
                 <div className="space-y-2 text-sm">
                   {conflicts.slice(0, 3).map((conflict, idx) => (
                     <p key={idx} className="text-secondary">
-                      <span className="font-medium">{conflict.intern?.full_name}</span> has task "{conflict.task.title}" 
-                      due on {format(new Date(conflict.deadline), 'MMM d')} during vacation
+                      {t("vacation.calendar.conflictDetail", {
+                        name: conflict.intern?.full_name,
+                        task: conflict.task.title,
+                        date: format(new Date(conflict.deadline), 'MMM d'),
+                      })}
                     </p>
                   ))}
                   {conflicts.length > 3 && (
-                    <p className="text-muted">...and {conflicts.length - 3} more</p>
+                    <p className="text-muted">{t("vacation.calendar.more", { count: conflicts.length - 3 })}</p>
                   )}
                 </div>
               </div>
@@ -206,26 +211,28 @@ export default function VacationCalendar({ requests, interns }) {
               <div className="space-y-1">
                 {dayRequests.map(request => {
                   const intern = internsById[request.intern_id];
+                  const internName = intern?.full_name || t("common.misc.unknown");
                   return (
                     <div
                       key={request.id}
                       className="text-xs p-1 rounded bg-success/20 text-success border border-success/30 truncate"
-                      title={`${intern?.full_name || 'Unknown'} - ${request.reason}`}
+                      title={`${internName}${request.reason ? ` - ${request.reason}` : ''}`}
                     >
-                      {intern?.avatar_url} {intern?.full_name?.split(' ')[0]}
+                      {intern?.avatar_url} {internName.split(' ')[0]}
                     </div>
                   );
                 })}
 
                 {dayPending.map(request => {
                   const intern = internsById[request.intern_id];
+                  const internName = intern?.full_name || t("common.misc.unknown");
                   return (
                     <div
                       key={request.id}
                       className="text-xs p-1 rounded bg-warning/20 text-warning border border-warning/30 border-dashed truncate"
-                      title={`${intern?.full_name || 'Unknown'} - Pending: ${request.reason}`}
+                      title={`${internName} - ${t("common.status.pending")}${request.reason ? `: ${request.reason}` : ''}`}
                     >
-                      {intern?.avatar_url} {intern?.full_name?.split(' ')[0]}
+                      {intern?.avatar_url} {internName.split(' ')[0]}
                     </div>
                   );
                 })}
@@ -238,15 +245,15 @@ export default function VacationCalendar({ requests, interns }) {
       <div className="flex gap-4 text-sm">
         <div className="flex items-center gap-2">
           <div className="w-4 h-4 rounded bg-success/20 border border-success/30"></div>
-          <span className="text-secondary">Approved</span>
+          <span className="text-secondary">{t("vacation.calendar.approved")}</span>
         </div>
         <div className="flex items-center gap-2">
           <div className="w-4 h-4 rounded bg-warning/20 border border-warning/30 border-dashed"></div>
-          <span className="text-secondary">Pending</span>
+          <span className="text-secondary">{t("vacation.calendar.pending")}</span>
         </div>
         <div className="flex items-center gap-2">
           <Badge variant="destructive" className="h-4 w-4 p-0 flex items-center justify-center text-xs">!</Badge>
-          <span className="text-secondary">Conflict</span>
+          <span className="text-secondary">{t("vacation.calendar.conflict")}</span>
         </div>
       </div>
     </div>

--- a/Ascenda Padrinho att/src/components/vacation/VacationRequestsPanel.jsx
+++ b/Ascenda Padrinho att/src/components/vacation/VacationRequestsPanel.jsx
@@ -29,6 +29,7 @@ import { format } from "date-fns";
 import { eventBus, EventTypes } from "../utils/eventBus";
 import VacationCalendar from "./VacationCalendar";
 import Avatar from "@/components/ui/Avatar";
+import { useTranslation } from "@/i18n";
 
 export default function VacationRequestsPanel() {
   const [requests, setRequests] = useState([]);
@@ -41,6 +42,7 @@ export default function VacationRequestsPanel() {
   const [emojiEditor, setEmojiEditor] = useState(null);
   const [emojiValue, setEmojiValue] = useState("");
   const [isUpdatingEmoji, setIsUpdatingEmoji] = useState(false);
+  const { t } = useTranslation();
 
   const loadData = useCallback(async () => {
     const [requestsData, internsData] = await Promise.all([
@@ -207,7 +209,7 @@ export default function VacationRequestsPanel() {
         <CardHeader>
           <CardTitle className="text-primary flex items-center gap-2">
             <Calendar className="w-5 h-5" />
-            Vacation Requests
+            {t("vacation.panelTitle")}
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -215,11 +217,11 @@ export default function VacationRequestsPanel() {
             <TabsList className="mb-6 bg-surface2">
               <TabsTrigger value="list" className="data-[state=active]:bg-surface">
                 <CalendarCheck className="w-4 h-4 mr-2" />
-                Requests List
+                {t("vacation.tabs.list")}
               </TabsTrigger>
               <TabsTrigger value="calendar" className="data-[state=active]:bg-surface">
                 <Calendar className="w-4 h-4 mr-2" />
-                Calendar View
+                {t("vacation.tabs.calendar")}
               </TabsTrigger>
             </TabsList>
 
@@ -227,17 +229,17 @@ export default function VacationRequestsPanel() {
               <div className="flex items-center justify-between mb-4">
                 <Select value={filterStatus} onValueChange={setFilterStatus}>
                   <SelectTrigger className="w-40 bg-surface2 border-border text-primary">
-                    <SelectValue placeholder="Filter" />
+                    <SelectValue placeholder={t("vacation.filterPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent className="bg-surface border-border">
-                    <SelectItem value="all">All Requests</SelectItem>
-                    <SelectItem value="pending">Pending</SelectItem>
-                    <SelectItem value="approved">Approved</SelectItem>
-                    <SelectItem value="rejected">Rejected</SelectItem>
+                    <SelectItem value="all">{t("common.filters.allRequests")}</SelectItem>
+                    <SelectItem value="pending">{t("common.status.pending")}</SelectItem>
+                    <SelectItem value="approved">{t("common.status.approved")}</SelectItem>
+                    <SelectItem value="rejected">{t("common.status.rejected")}</SelectItem>
                   </SelectContent>
                 </Select>
                 <span className="text-sm text-muted">
-                  {filteredRequests.length} request{filteredRequests.length !== 1 ? 's' : ''}
+                  {t("common.counts.requests", { count: filteredRequests.length })}
                 </span>
               </div>
 
@@ -245,12 +247,12 @@ export default function VacationRequestsPanel() {
                 {filteredRequests.map((request) => {
                   const intern = internsById[request.intern_id];
                   const isPending = request.status === 'pending';
-                  
+
                   return (
                     <article
                       key={request.id}
                       className="p-4 rounded-xl border border-border bg-surface2 hover:shadow-e1 transition-all"
-                      aria-label={`Vacation request from ${intern?.full_name || 'Unknown'}`}
+                      aria-label={t("vacation.aria.request", { name: intern?.full_name || t("common.misc.unknown") })}
                     >
                       <div className="grid grid-cols-[auto,1fr,auto] gap-4 items-start">
                         <div className="relative flex-shrink-0">
@@ -260,10 +262,10 @@ export default function VacationRequestsPanel() {
                                 type="button"
                                 onClick={() => openEmojiEditor(intern)}
                                 className="w-12 h-12 rounded-full bg-gradient-to-br from-brand to-brand2 flex items-center justify-center text-2xl transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-                                title={`Update profile emoji for ${intern.full_name}`}
+                                title={t("common.misc.updateProfileEmoji", { name: intern.full_name })}
                               >
                                 {intern.avatar_url || '👤'}
-                                <span className="sr-only">Update profile emoji for {intern.full_name}</span>
+                                <span className="sr-only">{t("common.misc.updateProfileEmoji", { name: intern.full_name })}</span>
                               </button>
                               <span className="absolute -bottom-1 -right-1 rounded-full bg-surface text-muted border border-border p-1 shadow-sm">
                                 <Pencil className="w-3 h-3" aria-hidden="true" />
@@ -279,42 +281,44 @@ export default function VacationRequestsPanel() {
                         <div className="min-w-0">
                           <div className="flex items-center gap-2 mb-2 flex-wrap">
                             <h3 className="font-semibold text-primary truncate max-w-[220px]">
-                              {intern?.full_name || 'Unknown'}
+                              {intern?.full_name || t("common.misc.unknown")}
                             </h3>
                             <Badge className={`${statusColors[request.status]} border capitalize flex-shrink-0`}>
-                              {request.status}
+                              {t(`common.status.${request.status}`)}
                             </Badge>
                           </div>
-                          
+
                           {intern && (
                             <p className="text-xs text-muted mb-2">{intern.track}</p>
                           )}
-                          
+
                           <div className="space-y-1 text-sm">
                             <p className="text-secondary">
-                              <span className="text-muted">From:</span>{' '}
+                              <span className="text-muted">{t("vacation.labels.from")}</span>{' '}
                               <span className="font-medium">
                                 {format(new Date(request.start_date), 'MMM d, yyyy')}
                               </span>
                             </p>
                             <p className="text-secondary">
-                              <span className="text-muted">To:</span>{' '}
+                              <span className="text-muted">{t("vacation.labels.to")}</span>{' '}
                               <span className="font-medium">
                                 {format(new Date(request.end_date), 'MMM d, yyyy')}
                               </span>
                             </p>
                             {request.reason && (
                               <p className="text-secondary mt-2">
-                                <span className="text-muted">Reason:</span> {request.reason}
+                                <span className="text-muted">{t("vacation.labels.reason")}</span> {request.reason}
                               </p>
                             )}
                             {request.manager_note && (
                               <p className="text-secondary mt-2 p-2 bg-surface rounded border border-border">
-                                <span className="text-muted">Manager note:</span> {request.manager_note}
+                                <span className="text-muted">{t("vacation.labels.managerNote")}</span> {request.manager_note}
                               </p>
                             )}
                             <p className="text-xs text-muted mt-2">
-                              Requested {format(new Date(request.created_date), 'MMM d, yyyy')}
+                              {t("vacation.labels.requested", {
+                                date: format(new Date(request.created_date), 'MMM d, yyyy'),
+                              })}
                             </p>
                           </div>
                         </div>
@@ -326,10 +330,10 @@ export default function VacationRequestsPanel() {
                               onClick={() => handleApprove(request)}
                               disabled={processingId === request.id}
                               className="bg-success hover:bg-success/90 text-white font-medium"
-                              aria-label={`Approve vacation request for ${intern?.full_name}`}
+                              aria-label={t("vacation.aria.approve", { name: intern?.full_name || t("common.misc.unknown") })}
                             >
                               <Check className="w-4 h-4 mr-1" />
-                              Approve
+                              {t("vacation.approve")}
                             </Button>
                             <Button
                               size="sm"
@@ -337,10 +341,10 @@ export default function VacationRequestsPanel() {
                               onClick={() => handleReject(request)}
                               disabled={processingId === request.id}
                               className="border-error text-error hover:bg-error/10 font-medium"
-                              aria-label={`Reject vacation request for ${intern?.full_name}`}
+                              aria-label={t("vacation.aria.reject", { name: intern?.full_name || t("common.misc.unknown") })}
                             >
                               <X className="w-4 h-4 mr-1" />
-                              Reject
+                              {t("vacation.reject")}
                             </Button>
                           </div>
                         )}
@@ -352,7 +356,7 @@ export default function VacationRequestsPanel() {
                 {filteredRequests.length === 0 && (
                   <div className="text-center py-12 bg-surface2 rounded-xl border border-border">
                     <AlertCircle className="w-12 h-12 mx-auto mb-3 text-muted opacity-50" />
-                    <p className="text-muted">No vacation requests found</p>
+                    <p className="text-muted">{t("vacation.none")}</p>
                   </div>
                 )}
               </div>
@@ -378,9 +382,9 @@ export default function VacationRequestsPanel() {
       >
         <DialogContent className="bg-surface border-border max-w-md">
           <DialogHeader>
-            <DialogTitle className="text-primary">Update Profile Emoji</DialogTitle>
+            <DialogTitle className="text-primary">{t("vacation.emoji.title")}</DialogTitle>
             <DialogDescription className="text-secondary">
-              Choose an emoji or paste an image URL for {emojiEditor?.full_name}.
+              {t("vacation.emoji.description", { name: emojiEditor?.full_name })}
             </DialogDescription>
           </DialogHeader>
 
@@ -390,15 +394,15 @@ export default function VacationRequestsPanel() {
                 <div className="w-full h-full rounded-full bg-surface flex items-center justify-center overflow-hidden">
                   <Avatar
                     src={previewEmoji}
-                    alt={emojiEditor?.full_name || 'Intern avatar preview'}
+                    alt={emojiEditor?.full_name || t("common.misc.emojiPreviewAlt")}
                     size={56}
                   />
                 </div>
               </div>
               <div className="min-w-0">
-                <p className="text-sm text-secondary">Preview</p>
+                <p className="text-sm text-secondary">{t("vacation.emoji.preview")}</p>
                 <p className="text-base font-semibold text-primary truncate max-w-[180px]">
-                  {emojiEditor?.full_name || 'Intern'}
+                  {emojiEditor?.full_name || t("common.misc.unknown")}
                 </p>
               </div>
             </div>
@@ -406,12 +410,10 @@ export default function VacationRequestsPanel() {
             <Input
               value={emojiValue}
               onChange={(e) => setEmojiValue(e.target.value)}
-              placeholder="Try 😀 or paste an image URL"
+              placeholder={t("common.placeholders.emojiInput")}
               className="bg-surface2 border-border text-primary"
             />
-            <p className="text-xs text-muted">
-              Emojis render beautifully across the app and you can swap them anytime. Image URLs are also supported.
-            </p>
+            <p className="text-xs text-muted">{t("common.misc.emojiHelp")}</p>
           </div>
 
           <DialogFooter>
@@ -424,14 +426,14 @@ export default function VacationRequestsPanel() {
               }}
               className="border-border"
             >
-              Cancel
+              {t("common.actions.cancel")}
             </Button>
             <Button
               onClick={saveEmoji}
               disabled={!emojiHasChanges || isUpdatingEmoji}
               className="bg-brand hover:bg-brand/90 text-white font-medium"
             >
-              Save Emoji
+              {t("common.actions.saveEmoji")}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -440,21 +442,21 @@ export default function VacationRequestsPanel() {
       <Dialog open={!!rejectDialog} onOpenChange={() => setRejectDialog(null)}>
         <DialogContent className="bg-surface border-border">
           <DialogHeader>
-            <DialogTitle className="text-primary">Reject Vacation Request</DialogTitle>
+            <DialogTitle className="text-primary">{t("vacation.rejectTitle")}</DialogTitle>
             <DialogDescription className="text-secondary">
-              Are you sure you want to reject this vacation request? You can optionally add a note.
+              {t("vacation.rejectDescription")}
             </DialogDescription>
           </DialogHeader>
-          
+
           <div className="space-y-4">
             <div>
               <label className="text-sm font-medium text-secondary mb-2 block">
-                Manager Note (Optional)
+                {t("vacation.managerNoteOptional")}
               </label>
               <Textarea
                 value={managerNote}
                 onChange={(e) => setManagerNote(e.target.value)}
-                placeholder="Explain the reason for rejection..."
+                placeholder={t("common.placeholders.rejectionReason")}
                 className="bg-surface2 border-border text-primary"
                 rows={3}
               />
@@ -467,7 +469,7 @@ export default function VacationRequestsPanel() {
               onClick={() => setRejectDialog(null)}
               className="border-border"
             >
-              Cancel
+              {t("common.actions.cancel")}
             </Button>
             <Button
               onClick={confirmReject}
@@ -475,7 +477,7 @@ export default function VacationRequestsPanel() {
               className="bg-error hover:bg-error/90 text-white font-medium"
             >
               <X className="w-4 h-4 mr-2" />
-              Reject Request
+              {t("vacation.rejectConfirm")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/Ascenda Padrinho att/src/i18n/index.jsx
+++ b/Ascenda Padrinho att/src/i18n/index.jsx
@@ -1,0 +1,124 @@
+import React from "react";
+import en from "./translations/en";
+import pt from "./translations/pt";
+
+const STORAGE_KEY = "ascenda-language";
+const resources = { en, pt };
+const fallbackLanguage = "en";
+
+const LanguageContext = React.createContext({
+  language: fallbackLanguage,
+  setLanguage: () => {},
+  toggleLanguage: () => {},
+  t: (key, options) => options?.defaultValue ?? key,
+});
+
+function resolvePath(dictionary, key) {
+  return key.split(".").reduce((acc, part) => (acc ? acc[part] : undefined), dictionary);
+}
+
+function formatValue(value, options = {}) {
+  if (typeof value === "function") {
+    return value(options);
+  }
+
+  if (typeof value === "string") {
+    return value.replace(/{{(.*?)}}/g, (_, token) => {
+      const trimmed = token.trim();
+      if (trimmed === "suffix") {
+        const count = Number(options.count ?? options.value ?? 0);
+        return count === 1 ? "" : options.suffix ?? "s";
+      }
+      if (trimmed === "value" && options.value !== undefined) {
+        return String(options.value);
+      }
+      if (options[trimmed] !== undefined) {
+        return String(options[trimmed]);
+      }
+      return "";
+    });
+  }
+
+  if (value == null) {
+    return undefined;
+  }
+
+  return value;
+}
+
+export function LanguageProvider({ children }) {
+  const [language, setLanguage] = React.useState(() => {
+    if (typeof window !== "undefined") {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored && resources[stored]) {
+        return stored;
+      }
+    }
+    return fallbackLanguage;
+  });
+
+  React.useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, language);
+    }
+  }, [language]);
+
+  const changeLanguage = React.useCallback((next) => {
+    if (resources[next]) {
+      setLanguage(next);
+    }
+  }, []);
+
+  const toggleLanguage = React.useCallback(() => {
+    setLanguage((prev) => (prev === "en" ? "pt" : "en"));
+  }, []);
+
+  const translate = React.useCallback(
+    (key, options = {}) => {
+      const langs = [language, fallbackLanguage];
+
+      for (const lang of langs) {
+        const dictionary = resources[lang];
+        const value = resolvePath(dictionary, key);
+        if (value !== undefined) {
+          const formatted = formatValue(value, options);
+          if (formatted !== undefined) {
+            return formatted;
+          }
+        }
+      }
+
+      return options.defaultValue ?? key;
+    },
+    [language]
+  );
+
+  const contextValue = React.useMemo(
+    () => ({
+      language,
+      setLanguage: changeLanguage,
+      toggleLanguage,
+      t: translate,
+    }),
+    [language, changeLanguage, toggleLanguage, translate]
+  );
+
+  return (
+    <LanguageContext.Provider value={contextValue}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const context = React.useContext(LanguageContext);
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+  return context;
+}
+
+export function useTranslation() {
+  const { t } = useLanguage();
+  return { t };
+}

--- a/Ascenda Padrinho att/src/i18n/translations/en.js
+++ b/Ascenda Padrinho att/src/i18n/translations/en.js
@@ -1,0 +1,371 @@
+const en = {
+  common: {
+    appName: "Ascenda",
+    managerPortal: "Manager Portal",
+    navigation: "Navigation",
+    manager: "Manager",
+    actions: {
+      logout: "Logout",
+      cancel: "Cancel",
+      save: "Save",
+      approve: "Approve",
+      reject: "Reject",
+      preview: "Preview",
+      edit: "Edit",
+      assign: "Assign",
+      assignTo: "Assign to",
+      markAllRead: "Mark all read",
+      export: "Export Report",
+      exportCsv: "Export CSV",
+      upload: "Add Course",
+      uploading: "Uploading...",
+      saveChanges: "Save Changes",
+      saving: "Saving...",
+      today: "Today",
+      startCourse: "Start Course",
+      markCompleted: "Mark as Completed",
+      assignCourse: "Assign Course",
+      close: "Close",
+      chat: "Chat",
+      view: "View",
+      open: "Open",
+      saveEmoji: "Save Emoji"
+    },
+    status: {
+      active: "Active",
+      paused: "Paused",
+      completed: "Completed",
+      approved: "Approved",
+      rejected: "Rejected",
+      pending: "Pending",
+      assigned: "Assigned",
+      inProgress: "In Progress",
+      overdue: "Overdue"
+    },
+    filters: {
+      level: "Level",
+      status: "Status",
+      allLevels: "All Levels",
+      allStatus: "All Status",
+      allRequests: "All Requests",
+      filter: "Filter"
+    },
+    languages: {
+      en: "English",
+      pt: "Português"
+    },
+    placeholders: {
+      searchInterns: "Search interns...",
+      courseTitleExample: "e.g., Advanced React Patterns",
+      courseDescription: "What will interns learn?",
+      youtubeUrl: "https://www.youtube.com/watch?v=...",
+      uploadPrompt: "Click to upload PDF, video, image, or Office file",
+      rejectionReason: "Explain the reason for rejection...",
+      notes: "Add any special instructions or context...",
+      emojiInput: "Try 😀 or paste an image URL"
+    },
+    labels: {
+      language: "Language",
+      descriptionOptional: "Description",
+      preview: "Preview",
+      durationHours: "Duration (hours)",
+      youtubeOptional: "YouTube Link (Optional)",
+      materialsOptional: "Course Materials (Optional)",
+      dueDateOptional: "Due Date (Optional)",
+      notesOptional: "Notes (Optional)",
+      managerNoteOptional: "Manager Note (Optional)",
+      previewTitle: "Preview"
+    },
+    time: {
+      daysLeft: "{{count}} days left",
+      requestedOn: "Requested {{date}}",
+      monthYear: "MMMM yyyy",
+      dayMonth: "MMM d",
+      dayMonthYear: "MMM d, yyyy",
+      monthDayTime: "MMM d, h:mm a"
+    },
+    counts: {
+      interns: "{{count}} interns",
+      requests: "{{count}} request{{suffix}}",
+      conflicts: "{{count}} Scheduling Conflict{{suffix}} Detected",
+      selectedInterns: "{{count}} intern{{suffix}} selected",
+      assignments: "Active Course Assignments ({{count}})"
+    },
+    misc: {
+      unknown: "Unknown",
+      learningTrack: "Learning Track",
+      progress: "Progress",
+      avg: "avg",
+      file: "File",
+      preview: "Preview",
+      courseLibraryCount: "{{count}} courses",
+      internsCount: "{{count}} interns",
+      emojiHelp: "Emojis render beautifully across the app and you can swap them anytime. Image URLs are also supported.",
+      updateProfileEmoji: "Update profile emoji for {{name}}",
+      emojiPreviewAlt: "Intern avatar preview"
+    }
+  },
+  layout: {
+    sidebarTagline: "Manager Portal",
+    nav: {
+      dashboard: "Dashboard",
+      interns: "Team Overview",
+      content: "Content Management",
+      vacation: "Vacation Requests",
+      reports: "Reports"
+    },
+    languageToggle: {
+      label: "Language",
+      english: "English",
+      portuguese: "Português"
+    }
+  },
+  dashboard: {
+    welcome: "Welcome back, {{name}}!",
+    subtitle: "Here's what's happening with your team today",
+    summary: {
+      totalInterns: "Total Interns",
+      courses: "Courses Available",
+      reviews: "Pending Reviews",
+      points: "Team Points",
+      trend: "+2 this month",
+      pointsTrend: "+15%"
+    },
+    sectionTitle: "Intern Status & Well-being",
+    performanceChart: {
+      noData: "No performance data available",
+      legendLabel: "Performance Score",
+      tooltipLabel: "{{label}}",
+      tooltipValue: "{{value}}%",
+      percentValue: "{{value}}%",
+    },
+    notifications: {
+      pausedTitle: "Intern Paused",
+      resumedTitle: "Intern Resumed",
+      pausedBody: "Learning system paused for {{name}}",
+      resumedBody: "Learning system resumed for {{name}}",
+    }
+  },
+  internsPage: {
+    title: "Team Overview",
+    subtitle: "Manage and track your team's progress",
+    noResults: "No interns found matching your filters",
+    levels: {
+      novice: "Novice",
+      apprentice: "Apprentice",
+      journeyman: "Journeyman",
+      expert: "Expert",
+      master: "Master"
+    }
+  },
+  internStatus: {
+    tooltip: "Well-being: {{status}}",
+    trackFallback: "Learning Track",
+    internshipProgress: "Internship Progress",
+    daysLeft: "{{count}} days left",
+    systemStatus: "System Status",
+    labels: {
+      excellent: "Excellent",
+      good: "Good",
+      neutral: "Neutral",
+      stressed: "Stressed",
+      overwhelmed: "Overwhelmed"
+    }
+  },
+  internCard: {
+    points: "Points:",
+    average: "{{value}}% avg",
+    daysLeftShort: "{{count}}d left",
+    chat: "Chat"
+  },
+  internDetails: {
+    totalPoints: "Total Points",
+    tasksDone: "Tasks Done",
+    startDate: "Start Date",
+    endDate: "End Date",
+    daysLeft: "{{count}} days left",
+    tabs: {
+      performance: "Performance",
+      courses: "Active Courses"
+    },
+    skills: "Skills",
+    noPerformance: "No performance data available yet"
+  },
+  performance: {
+    title: "Performance Insights",
+    currentScore: "Current Score",
+    average: "3-Mo Avg",
+    completed: "Completed",
+    studyHours: "Study Hours",
+    target: "Target 85%",
+    completionSeries: "Completion %",
+    scoreSeries: "Score %",
+    pointsSeries: "Points",
+    tooltip: {
+      score: "Score:",
+      completion: "Completion:",
+      points: "Points:",
+      hours: "Hours:"
+    },
+    export: "Export CSV"
+  },
+  assignments: {
+    title: "Active Course Assignments",
+    none: "No active course assignments",
+    assigned: "Assigned",
+    inProgress: "In Progress",
+    progress: "Progress",
+    assignedOn: "Assigned {{date}}",
+    dueOn: "Due {{date}}",
+    startCourse: "Start Course",
+    markCompleted: "Mark as Completed"
+  },
+  content: {
+    title: "Content Management",
+    subtitle: "Create and manage training materials for your team",
+    libraryTitle: "Course Library",
+    noCourses: "No courses yet. Create your first one!",
+    addCourse: "Add New Course"
+  },
+  courseForm: {
+    titleLabel: "Course Title *",
+    descriptionLabel: "Description *",
+    categoryLabel: "Category",
+    difficultyLabel: "Difficulty",
+    durationLabel: "Duration (hours)",
+    youtubeLabel: "YouTube Link (Optional)",
+    materialsLabel: "Course Materials (Optional)",
+    previewButton: "Preview Document",
+    categories: {
+      technical: "Technical",
+      leadership: "Leadership",
+      communication: "Communication",
+      design: "Design",
+      business: "Business"
+    },
+    difficulties: {
+      beginner: "Beginner",
+      intermediate: "Intermediate",
+      advanced: "Advanced"
+    }
+  },
+  courseCard: {
+    youtube: "YouTube",
+    active: "{{count}} active",
+    edit: "Edit",
+    assign: "Assign",
+    preview: "Preview"
+  },
+  courseEdit: {
+    title: "Edit Course",
+    cancel: "Cancel",
+    save: "Save Changes"
+  },
+  assignModal: {
+    title: "Assign \"{{course}}\" to Interns",
+    selectInterns: "Select Interns *",
+    noneAvailable: "No active interns available",
+    selectedCount: "{{count}} intern{{suffix}} selected",
+    dueDate: "Due Date (Optional)",
+    notes: "Notes (Optional)",
+    assigning: "Assigning...",
+    assignTo: "Assign to {{count}} Intern{{suffix}}"
+  },
+  reports: {
+    title: "Reports & Analytics",
+    subtitle: "Insights into your team's performance and progress",
+    export: "Export Report",
+    teamPerformance: "Team Performance (Top 10)",
+    teamPerformancePoints: {
+      singular: "point",
+      plural: "points",
+    },
+    taskDistribution: "Task Distribution",
+    keyMetrics: "Key Metrics Summary",
+    totalInterns: "Total Interns",
+    activeTasks: "Active Tasks",
+    availableCourses: "Available Courses",
+    avgPoints: "Avg. Points",
+    noTaskData: "No task data available",
+    taskCompletion: {
+      label: "{{status}}: {{percent}}",
+      taskSingular: "task",
+      taskPlural: "tasks",
+    }
+  },
+  vacation: {
+    title: "Vacation Requests",
+    subtitle: "Review and manage intern vacation requests",
+    panelTitle: "Vacation Requests",
+    tabs: {
+      list: "Requests List",
+      calendar: "Calendar View"
+    },
+    filterPlaceholder: "Filter",
+    none: "No vacation requests found",
+    approve: "Approve",
+    reject: "Reject",
+    rejectTitle: "Reject Vacation Request",
+    rejectDescription: "Are you sure you want to reject this vacation request? You can optionally add a note.",
+    rejectConfirm: "Reject Request",
+    managerNoteOptional: "Manager Note (Optional)",
+    labels: {
+      from: "From:",
+      to: "To:",
+      reason: "Reason:",
+      managerNote: "Manager note:",
+      requested: "Requested {{date}}"
+    },
+    aria: {
+      request: "Vacation request from {{name}}",
+      approve: "Approve vacation request for {{name}}",
+      reject: "Reject vacation request for {{name}}"
+    },
+    emoji: {
+      title: "Update Profile Emoji",
+      description: "Choose an emoji or paste an image URL for {{name}}.",
+      preview: "Preview",
+      cancel: "Cancel"
+    },
+    conflictLegend: {
+      approved: "Approved",
+      pending: "Pending",
+      conflict: "Conflict"
+    },
+    calendar: {
+      months: {
+        conflict: "{{count}} Scheduling Conflict{{suffix}} Detected"
+      },
+      approved: "Approved",
+      pending: "Pending",
+      conflict: "Conflict",
+      buttonToday: "Today",
+      previousMonth: "Previous month",
+      nextMonth: "Next month",
+      more: "...and {{count}} more",
+      conflictDetail: "{{name}} has task \"{{task}}\" due on {{date}} during vacation"
+    }
+  },
+  notifications: {
+    title: "Notifications",
+    markAllRead: "Mark all read",
+    today: "Today",
+    thisWeek: "This Week",
+    earlier: "Earlier",
+    none: "No notifications yet",
+    by: "By {{name}}"
+  },
+  youtube: {
+    invalid: "Invalid YouTube URL. Please check the link.",
+    detected: "YouTube Video Detected",
+    thumbnailAlt: "Video thumbnail",
+    playOverlay: "Preview of YouTube video"
+  },
+  chat: {
+    title: "Chat conversation",
+    empty: "No messages yet. Start the conversation!",
+    placeholder: "Type a message... (Enter to send, Shift+Enter for new line)"
+  }
+};
+
+export default en;

--- a/Ascenda Padrinho att/src/i18n/translations/pt.js
+++ b/Ascenda Padrinho att/src/i18n/translations/pt.js
@@ -1,0 +1,371 @@
+const pt = {
+  common: {
+    appName: "Ascenda",
+    managerPortal: "Portal do Gestor",
+    navigation: "Navegação",
+    manager: "Gestor",
+    actions: {
+      logout: "Sair",
+      cancel: "Cancelar",
+      save: "Salvar",
+      approve: "Aprovar",
+      reject: "Rejeitar",
+      preview: "Pré-visualizar",
+      edit: "Editar",
+      assign: "Atribuir",
+      assignTo: "Atribuir a",
+      markAllRead: "Marcar tudo como lido",
+      export: "Exportar relatório",
+      exportCsv: "Exportar CSV",
+      upload: "Adicionar curso",
+      uploading: "Enviando...",
+      saveChanges: "Salvar alterações",
+      saving: "Salvando...",
+      today: "Hoje",
+      startCourse: "Iniciar curso",
+      markCompleted: "Marcar como concluído",
+      assignCourse: "Atribuir curso",
+      close: "Fechar",
+      chat: "Chat",
+      view: "Ver",
+      open: "Abrir",
+      saveEmoji: "Salvar emoji"
+    },
+    status: {
+      active: "Ativo",
+      paused: "Pausado",
+      completed: "Concluído",
+      approved: "Aprovado",
+      rejected: "Rejeitado",
+      pending: "Pendente",
+      assigned: "Atribuído",
+      inProgress: "Em andamento",
+      overdue: "Em atraso"
+    },
+    filters: {
+      level: "Nível",
+      status: "Status",
+      allLevels: "Todos os níveis",
+      allStatus: "Todos os status",
+      allRequests: "Todas as solicitações",
+      filter: "Filtrar"
+    },
+    languages: {
+      en: "English",
+      pt: "Português"
+    },
+    placeholders: {
+      searchInterns: "Pesquisar estagiários...",
+      courseTitleExample: "ex.: Padrões Avançados de React",
+      courseDescription: "O que os estagiários vão aprender?",
+      youtubeUrl: "https://www.youtube.com/watch?v=...",
+      uploadPrompt: "Clique para enviar PDF, vídeo, imagem ou arquivo do Office",
+      rejectionReason: "Explique o motivo da rejeição...",
+      notes: "Adicione instruções ou contexto...",
+      emojiInput: "Experimente 😀 ou cole uma URL de imagem"
+    },
+    labels: {
+      language: "Idioma",
+      descriptionOptional: "Descrição",
+      preview: "Pré-visualização",
+      durationHours: "Duração (horas)",
+      youtubeOptional: "Link do YouTube (opcional)",
+      materialsOptional: "Materiais do curso (opcional)",
+      dueDateOptional: "Data limite (opcional)",
+      notesOptional: "Observações (opcional)",
+      managerNoteOptional: "Nota do gestor (opcional)",
+      previewTitle: "Pré-visualização"
+    },
+    time: {
+      daysLeft: "{{count}} dias restantes",
+      requestedOn: "Solicitado em {{date}}",
+      monthYear: "MMMM 'de' yyyy",
+      dayMonth: "d 'de' MMM",
+      dayMonthYear: "d 'de' MMM',' yyyy",
+      monthDayTime: "d 'de' MMM, HH:mm"
+    },
+    counts: {
+      interns: "{{count}} estagiário{{suffix}}",
+      requests: "{{count}} solicitação{{suffix}}",
+      conflicts: "{{count}} conflito{{suffix}} de agenda detectado",
+      selectedInterns: "{{count}} estagiário{{suffix}} selecionado",
+      assignments: "Atribuições de cursos ativas ({{count}})"
+    },
+    misc: {
+      unknown: "Desconhecido",
+      learningTrack: "Trilha de aprendizado",
+      progress: "Progresso",
+      avg: "média",
+      file: "Arquivo",
+      preview: "Prévia",
+      courseLibraryCount: "{{count}} cursos",
+      internsCount: "{{count}} estagiário{{suffix}}",
+      emojiHelp: "Emojis ficam ótimos no app e você pode trocá-los quando quiser. URLs de imagens também são suportadas.",
+      updateProfileEmoji: "Atualizar emoji do perfil de {{name}}",
+      emojiPreviewAlt: "Prévia do avatar do estagiário"
+    }
+  },
+  layout: {
+    sidebarTagline: "Portal do Gestor",
+    nav: {
+      dashboard: "Dashboard",
+      interns: "Equipe",
+      content: "Gestão de conteúdo",
+      vacation: "Férias",
+      reports: "Relatórios"
+    },
+    languageToggle: {
+      label: "Idioma",
+      english: "English",
+      portuguese: "Português"
+    }
+  },
+  dashboard: {
+    welcome: "Bem-vindo de volta, {{name}}!",
+    subtitle: "Veja o que está acontecendo com a sua equipe hoje",
+    summary: {
+      totalInterns: "Total de estagiários",
+      courses: "Cursos disponíveis",
+      reviews: "Revisões pendentes",
+      points: "Pontos da equipe",
+      trend: "+2 este mês",
+      pointsTrend: "+15%"
+    },
+    sectionTitle: "Status e bem-estar dos estagiários",
+    performanceChart: {
+      noData: "Nenhum dado de performance disponível",
+      legendLabel: "Pontuação de performance",
+      tooltipLabel: "{{label}}",
+      tooltipValue: "{{value}}%",
+      percentValue: "{{value}}%",
+    },
+    notifications: {
+      pausedTitle: "Estagiário pausado",
+      resumedTitle: "Estagiário retomado",
+      pausedBody: "Sistema de aprendizagem pausado para {{name}}",
+      resumedBody: "Sistema de aprendizagem retomado para {{name}}",
+    }
+  },
+  internsPage: {
+    title: "Equipe",
+    subtitle: "Gerencie e acompanhe o progresso da sua equipe",
+    noResults: "Nenhum estagiário encontrado com os filtros selecionados",
+    levels: {
+      novice: "Novato",
+      apprentice: "Aprendiz",
+      journeyman: "Profissional",
+      expert: "Especialista",
+      master: "Mestre"
+    }
+  },
+  internStatus: {
+    tooltip: "Bem-estar: {{status}}",
+    trackFallback: "Trilha de aprendizado",
+    internshipProgress: "Progresso do estágio",
+    daysLeft: "{{count}} dias restantes",
+    systemStatus: "Status do sistema",
+    labels: {
+      excellent: "Excelente",
+      good: "Bom",
+      neutral: "Neutro",
+      stressed: "Estressado",
+      overwhelmed: "Sobrecarregado"
+    }
+  },
+  internCard: {
+    points: "Pontos:",
+    average: "{{value}}% média",
+    daysLeftShort: "{{count}}d restantes",
+    chat: "Chat"
+  },
+  internDetails: {
+    totalPoints: "Total de pontos",
+    tasksDone: "Tarefas concluídas",
+    startDate: "Data de início",
+    endDate: "Data de término",
+    daysLeft: "{{count}} dias restantes",
+    tabs: {
+      performance: "Performance",
+      courses: "Cursos ativos"
+    },
+    skills: "Competências",
+    noPerformance: "Ainda não há dados de performance"
+  },
+  performance: {
+    title: "Insights de performance",
+    currentScore: "Pontuação atual",
+    average: "Média 3 meses",
+    completed: "Concluídos",
+    studyHours: "Horas de estudo",
+    target: "Meta 85%",
+    completionSeries: "Conclusão %",
+    scoreSeries: "Pontuação %",
+    pointsSeries: "Pontos",
+    tooltip: {
+      score: "Pontuação:",
+      completion: "Conclusão:",
+      points: "Pontos:",
+      hours: "Horas:"
+    },
+    export: "Exportar CSV"
+  },
+  assignments: {
+    title: "Atribuições de cursos ativas",
+    none: "Nenhuma atribuição de curso ativa",
+    assigned: "Atribuído",
+    inProgress: "Em andamento",
+    progress: "Progresso",
+    assignedOn: "Atribuído em {{date}}",
+    dueOn: "Entrega em {{date}}",
+    startCourse: "Iniciar curso",
+    markCompleted: "Marcar como concluído"
+  },
+  content: {
+    title: "Gestão de conteúdo",
+    subtitle: "Crie e gerencie materiais de treinamento para sua equipe",
+    libraryTitle: "Biblioteca de cursos",
+    noCourses: "Ainda não há cursos. Crie o primeiro!",
+    addCourse: "Adicionar novo curso"
+  },
+  courseForm: {
+    titleLabel: "Título do curso *",
+    descriptionLabel: "Descrição *",
+    categoryLabel: "Categoria",
+    difficultyLabel: "Dificuldade",
+    durationLabel: "Duração (horas)",
+    youtubeLabel: "Link do YouTube (opcional)",
+    materialsLabel: "Materiais do curso (opcional)",
+    previewButton: "Pré-visualizar documento",
+    categories: {
+      technical: "Técnica",
+      leadership: "Liderança",
+      communication: "Comunicação",
+      design: "Design",
+      business: "Negócios"
+    },
+    difficulties: {
+      beginner: "Iniciante",
+      intermediate: "Intermediário",
+      advanced: "Avançado"
+    }
+  },
+  courseCard: {
+    youtube: "YouTube",
+    active: "{{count}} ativo{{suffix}}",
+    edit: "Editar",
+    assign: "Atribuir",
+    preview: "Pré-visualizar"
+  },
+  courseEdit: {
+    title: "Editar curso",
+    cancel: "Cancelar",
+    save: "Salvar alterações"
+  },
+  assignModal: {
+    title: "Atribuir \"{{course}}\" aos estagiários",
+    selectInterns: "Selecione os estagiários *",
+    noneAvailable: "Nenhum estagiário ativo disponível",
+    selectedCount: "{{count}} estagiário{{suffix}} selecionado",
+    dueDate: "Data limite (opcional)",
+    notes: "Observações (opcional)",
+    assigning: "Atribuindo...",
+    assignTo: "Atribuir a {{count}} estagiário{{suffix}}"
+  },
+  reports: {
+    title: "Relatórios e análises",
+    subtitle: "Insights sobre o desempenho e progresso da equipe",
+    export: "Exportar relatório",
+    teamPerformance: "Performance da equipe (Top 10)",
+    teamPerformancePoints: {
+      singular: "ponto",
+      plural: "pontos",
+    },
+    taskDistribution: "Distribuição de tarefas",
+    keyMetrics: "Resumo de métricas",
+    totalInterns: "Total de estagiários",
+    activeTasks: "Tarefas ativas",
+    availableCourses: "Cursos disponíveis",
+    avgPoints: "Pontuação média",
+    noTaskData: "Nenhum dado de tarefas disponível",
+    taskCompletion: {
+      label: "{{status}}: {{percent}}",
+      taskSingular: "tarefa",
+      taskPlural: "tarefas",
+    }
+  },
+  vacation: {
+    title: "Solicitações de férias",
+    subtitle: "Analise e gerencie os pedidos de férias dos estagiários",
+    panelTitle: "Solicitações de férias",
+    tabs: {
+      list: "Lista de solicitações",
+      calendar: "Visão em calendário"
+    },
+    filterPlaceholder: "Filtrar",
+    none: "Nenhuma solicitação de férias encontrada",
+    approve: "Aprovar",
+    reject: "Rejeitar",
+    rejectTitle: "Rejeitar solicitação de férias",
+    rejectDescription: "Tem certeza de que deseja rejeitar esta solicitação? Você pode adicionar uma observação.",
+    rejectConfirm: "Rejeitar solicitação",
+    managerNoteOptional: "Nota do gestor (opcional)",
+    labels: {
+      from: "De:",
+      to: "Até:",
+      reason: "Motivo:",
+      managerNote: "Nota do gestor:",
+      requested: "Solicitado em {{date}}"
+    },
+    aria: {
+      request: "Solicitação de férias de {{name}}",
+      approve: "Aprovar solicitação de férias de {{name}}",
+      reject: "Rejeitar solicitação de férias de {{name}}"
+    },
+    emoji: {
+      title: "Atualizar emoji do perfil",
+      description: "Escolha um emoji ou cole uma URL de imagem para {{name}}.",
+      preview: "Pré-visualização",
+      cancel: "Cancelar"
+    },
+    conflictLegend: {
+      approved: "Aprovado",
+      pending: "Pendente",
+      conflict: "Conflito"
+    },
+    calendar: {
+      months: {
+        conflict: "{{count}} conflito{{suffix}} de agenda detectado"
+      },
+      approved: "Aprovado",
+      pending: "Pendente",
+      conflict: "Conflito",
+      buttonToday: "Hoje",
+      previousMonth: "Mês anterior",
+      nextMonth: "Próximo mês",
+      more: "...e mais {{count}}",
+      conflictDetail: "{{name}} tem a tarefa \"{{task}}\" com prazo em {{date}} durante as férias"
+    }
+  },
+  notifications: {
+    title: "Notificações",
+    markAllRead: "Marcar tudo como lido",
+    today: "Hoje",
+    thisWeek: "Esta semana",
+    earlier: "Anterior",
+    none: "Nenhuma notificação ainda",
+    by: "Por {{name}}"
+  },
+  youtube: {
+    invalid: "URL do YouTube inválida. Verifique o link.",
+    detected: "Vídeo do YouTube identificado",
+    thumbnailAlt: "Miniatura do vídeo",
+    playOverlay: "Pré-visualização do vídeo do YouTube"
+  },
+  chat: {
+    title: "Conversa",
+    empty: "Ainda não há mensagens. Comece a conversa!",
+    placeholder: "Digite uma mensagem... (Enter para enviar, Shift+Enter para nova linha)"
+  }
+};
+
+export default pt;

--- a/Ascenda Padrinho att/src/pages/ContentManagement.jsx
+++ b/Ascenda Padrinho att/src/pages/ContentManagement.jsx
@@ -6,6 +6,7 @@ import CourseCard from "../components/content/CourseCard";
 import CourseEditModal from "../components/content/CourseEditModal";
 import PreviewDrawer from "../components/media/PreviewDrawer";
 import AssignCourseModal from "../components/courses/AssignCourseModal";
+import { useTranslation } from "@/i18n";
 
 export default function ContentManagement() {
   const [courses, setCourses] = useState([]);
@@ -15,6 +16,7 @@ export default function ContentManagement() {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [assigningCourse, setAssigningCourse] = useState(null);
   const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
+  const { t } = useTranslation();
 
   const loadCourses = useCallback(async () => {
     const data = await Course.list('-created_date');
@@ -67,14 +69,14 @@ export default function ContentManagement() {
           animate={{ opacity: 1, y: 0 }}
         >
           <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-            Content Management
+            {t("content.title")}
           </h1>
-          <p className="text-muted">Create and manage training materials for your team</p>
+          <p className="text-muted">{t("content.subtitle")}</p>
         </motion.div>
 
         <div className="grid lg:grid-cols-3 gap-8">
           <div className="lg:col-span-1">
-            <CourseUploadForm 
+            <CourseUploadForm
               onSuccess={handleCourseCreate}
               onPreview={handleFormPreview}
             />
@@ -82,13 +84,13 @@ export default function ContentManagement() {
 
           <div className="lg:col-span-2 space-y-6">
             <div className="flex items-center justify-between">
-              <h2 className="text-2xl font-bold text-primary">Course Library</h2>
-              <span className="text-sm text-muted">{courses.length} courses</span>
+              <h2 className="text-2xl font-bold text-primary">{t("content.libraryTitle")}</h2>
+              <span className="text-sm text-muted">{t("common.misc.courseLibraryCount", { count: courses.length })}</span>
             </div>
 
             <div className="grid gap-6">
               {courses.map((course, index) => (
-                <CourseCard 
+                <CourseCard
                   key={course.id} 
                   course={course} 
                   index={index}
@@ -101,7 +103,7 @@ export default function ContentManagement() {
 
             {courses.length === 0 && (
               <div className="text-center py-12 bg-surface2 border border-border rounded-xl">
-                <p className="text-muted">No courses yet. Create your first one!</p>
+                <p className="text-muted">{t("content.noCourses")}</p>
               </div>
             )}
           </div>

--- a/Ascenda Padrinho att/src/pages/Dashboard.jsx
+++ b/Ascenda Padrinho att/src/pages/Dashboard.jsx
@@ -9,12 +9,14 @@ import SummaryCard from "../components/dashboard/SummaryCard";
 import InternStatusCard from "../components/dashboard/InternStatusCard";
 import { motion } from "framer-motion";
 import { eventBus, EventTypes } from "../components/utils/eventBus";
+import { useTranslation } from "@/i18n";
 
 export default function Dashboard() {
   const [interns, setInterns] = useState([]);
   const [courses, setCourses] = useState([]);
   const [tasks, setTasks] = useState([]);
   const [user, setUser] = useState(null);
+  const { t } = useTranslation();
 
   useEffect(() => {
     loadData();
@@ -54,12 +56,18 @@ export default function Dashboard() {
     await Intern.update(intern.id, { status: newStatus });
 
     await Notification.create({
-      type: newStatus === 'paused' ? 'intern_paused' : 'intern_resumed',
-      title: `Intern ${newStatus === 'paused' ? 'Paused' : 'Resumed'}`,
-      body: `Learning system ${newStatus === 'paused' ? 'paused' : 'resumed'} for ${intern.full_name}`,
+      type: newStatus === "paused" ? "intern_paused" : "intern_resumed",
+      title:
+        newStatus === "paused"
+          ? t("dashboard.notifications.pausedTitle")
+          : t("dashboard.notifications.resumedTitle"),
+      body:
+        newStatus === "paused"
+          ? t("dashboard.notifications.pausedBody", { name: intern.full_name })
+          : t("dashboard.notifications.resumedBody", { name: intern.full_name }),
       target_id: intern.id,
-      target_kind: 'intern',
-      actor_name: user?.full_name || 'Manager'
+      target_kind: "intern",
+      actor_name: user?.full_name || t("common.manager"),
     });
 
     eventBus.emit(newStatus === 'paused' ? EventTypes.INTERN_PAUSED : EventTypes.INTERN_RESUMED, {
@@ -80,48 +88,50 @@ export default function Dashboard() {
           animate={{ opacity: 1, y: 0 }}
         >
           <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-            Welcome back, {user?.full_name || 'Manager'}!
+            {t("dashboard.welcome", { name: user?.full_name || t("common.manager") })}
           </h1>
-          <p className="text-muted">Here's what's happening with your team today</p>
+          <p className="text-muted">{t("dashboard.subtitle")}</p>
         </motion.div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <SummaryCard
-            title="Total Interns"
+            title={t("dashboard.summary.totalInterns")}
             value={interns.length}
             icon={Users}
             gradient="bg-gradient-to-br from-brand to-blue-600"
-            trend="+2 this month"
+            trend={t("dashboard.summary.trend")}
             delay={0.1}
           />
           <SummaryCard
-            title="Courses Available"
+            title={t("dashboard.summary.courses")}
             value={courses.length}
             icon={BookOpen}
             gradient="bg-gradient-to-br from-brand2 to-pink-600"
             delay={0.2}
           />
           <SummaryCard
-            title="Pending Reviews"
+            title={t("dashboard.summary.reviews")}
             value={pendingTasks}
             icon={ClipboardCheck}
             gradient="bg-gradient-to-br from-brand2 to-yellow-600"
             delay={0.3}
           />
           <SummaryCard
-            title="Team Points"
+            title={t("dashboard.summary.points")}
             value={totalPoints}
             icon={Trophy}
             gradient="bg-gradient-to-br from-yellow-600 to-pink-600"
-            trend="+15%"
+            trend={t("dashboard.summary.pointsTrend")}
             delay={0.4}
           />
         </div>
 
         <div>
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-2xl font-bold text-primary">Intern Status & Well-being</h2>
-            <span className="text-sm text-muted">{interns.length} interns</span>
+            <h2 className="text-2xl font-bold text-primary">{t("dashboard.sectionTitle")}</h2>
+            <span className="text-sm text-muted">
+              {t("common.counts.interns", { count: interns.length })}
+            </span>
           </div>
           
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/Ascenda Padrinho att/src/pages/Interns.jsx
+++ b/Ascenda Padrinho att/src/pages/Interns.jsx
@@ -13,6 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useTranslation } from "@/i18n";
 
 export default function Interns() {
   const [interns, setInterns] = useState([]);
@@ -23,6 +24,7 @@ export default function Interns() {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterLevel, setFilterLevel] = useState("all");
   const [filterStatus, setFilterStatus] = useState("all");
+  const { t } = useTranslation();
 
   useEffect(() => {
     loadInterns();
@@ -71,9 +73,9 @@ export default function Interns() {
         >
           <div>
             <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-              Team Overview
+              {t("internsPage.title")}
             </h1>
-            <p className="text-muted">Manage and track your team's progress</p>
+            <p className="text-muted">{t("internsPage.subtitle")}</p>
           </div>
         </motion.div>
 
@@ -81,7 +83,7 @@ export default function Interns() {
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-muted" />
             <Input
-              placeholder="Search interns..."
+              placeholder={t("common.placeholders.searchInterns")}
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               className="pl-10 bg-surface border-border text-primary placeholder:text-muted focus:border-brand"
@@ -91,28 +93,28 @@ export default function Interns() {
           <Select value={filterLevel} onValueChange={setFilterLevel}>
             <SelectTrigger className="w-full md:w-40 bg-surface border-border text-primary">
               <Filter className="w-4 h-4 mr-2" />
-              <SelectValue placeholder="Level" />
+              <SelectValue placeholder={t("common.filters.level")} />
             </SelectTrigger>
             <SelectContent className="bg-surface border-border">
-              <SelectItem value="all">All Levels</SelectItem>
-              <SelectItem value="Novice">Novice</SelectItem>
-              <SelectItem value="Apprentice">Apprentice</SelectItem>
-              <SelectItem value="Journeyman">Journeyman</SelectItem>
-              <SelectItem value="Expert">Expert</SelectItem>
-              <SelectItem value="Master">Master</SelectItem>
+              <SelectItem value="all">{t("common.filters.allLevels")}</SelectItem>
+              <SelectItem value="Novice">{t("internsPage.levels.novice")}</SelectItem>
+              <SelectItem value="Apprentice">{t("internsPage.levels.apprentice")}</SelectItem>
+              <SelectItem value="Journeyman">{t("internsPage.levels.journeyman")}</SelectItem>
+              <SelectItem value="Expert">{t("internsPage.levels.expert")}</SelectItem>
+              <SelectItem value="Master">{t("internsPage.levels.master")}</SelectItem>
             </SelectContent>
           </Select>
 
           <Select value={filterStatus} onValueChange={setFilterStatus}>
             <SelectTrigger className="w-full md:w-40 bg-surface border-border text-primary">
               <Filter className="w-4 h-4 mr-2" />
-              <SelectValue placeholder="Status" />
+              <SelectValue placeholder={t("common.filters.status")} />
             </SelectTrigger>
             <SelectContent className="bg-surface border-border">
-              <SelectItem value="all">All Status</SelectItem>
-              <SelectItem value="active">Active</SelectItem>
-              <SelectItem value="paused">Paused</SelectItem>
-              <SelectItem value="completed">Completed</SelectItem>
+              <SelectItem value="all">{t("common.filters.allStatus")}</SelectItem>
+              <SelectItem value="active">{t("common.status.active")}</SelectItem>
+              <SelectItem value="paused">{t("common.status.paused")}</SelectItem>
+              <SelectItem value="completed">{t("common.status.completed")}</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -131,7 +133,7 @@ export default function Interns() {
 
         {filteredInterns.length === 0 && (
           <div className="text-center py-12">
-            <p className="text-muted">No interns found matching your filters</p>
+            <p className="text-muted">{t("internsPage.noResults")}</p>
           </div>
         )}
 

--- a/Ascenda Padrinho att/src/pages/Reports.jsx
+++ b/Ascenda Padrinho att/src/pages/Reports.jsx
@@ -8,11 +8,13 @@ import { Download } from "lucide-react";
 import { motion } from "framer-motion";
 import TeamPerformanceChart from "../components/reports/TeamPerformanceChart";
 import TaskCompletionChart from "../components/reports/TaskCompletionChart";
+import { useTranslation } from "@/i18n";
 
 export default function Reports() {
   const [interns, setInterns] = useState([]);
   const [tasks, setTasks] = useState([]);
   const [courses, setCourses] = useState([]);
+  const { t } = useTranslation();
 
   useEffect(() => {
     loadData();
@@ -29,9 +31,9 @@ export default function Reports() {
     setCourses(coursesData);
   };
 
-  const performanceData = interns.slice(0, 10).map(intern => ({
-    name: intern.full_name?.split(' ')[0] || 'Unknown',
-    points: intern.points || 0
+  const performanceData = interns.slice(0, 10).map((intern) => ({
+    name: intern.full_name?.split(" ")[0] || t("common.misc.unknown"),
+    points: intern.points || 0,
   }));
 
   const taskStatusData = [
@@ -76,16 +78,16 @@ export default function Reports() {
         >
           <div>
             <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-              Reports & Analytics
+              {t("reports.title")}
             </h1>
-            <p className="text-muted">Insights into your team's performance and progress</p>
+            <p className="text-muted">{t("reports.subtitle")}</p>
           </div>
           <Button
             onClick={downloadReport}
             className="bg-brand hover:bg-brand/90 text-white"
           >
             <Download className="w-4 h-4 mr-2" />
-            Export Report
+            {t("reports.export")}
           </Button>
         </motion.div>
 
@@ -93,7 +95,7 @@ export default function Reports() {
           <Card className="border-border bg-surface shadow-e1">
             <CardHeader>
               <CardTitle className="text-primary">
-                Team Performance (Top 10)
+                {t("reports.teamPerformance")}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -106,7 +108,7 @@ export default function Reports() {
           <Card className="border-border bg-surface shadow-e1">
             <CardHeader>
               <CardTitle className="text-primary">
-                Task Distribution
+                {t("reports.taskDistribution")}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -120,25 +122,25 @@ export default function Reports() {
         <Card className="border-border bg-surface shadow-e1">
           <CardHeader>
             <CardTitle className="text-primary">
-              Key Metrics Summary
+              {t("reports.keyMetrics")}
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
               <div className="text-center p-4 bg-surface2 rounded-xl border border-border">
-                <p className="text-sm text-muted mb-2">Total Interns</p>
+                <p className="text-sm text-muted mb-2">{t("reports.totalInterns")}</p>
                 <p className="text-3xl font-bold text-primary">{interns.length}</p>
               </div>
               <div className="text-center p-4 bg-surface2 rounded-xl border border-border">
-                <p className="text-sm text-muted mb-2">Active Tasks</p>
+                <p className="text-sm text-muted mb-2">{t("reports.activeTasks")}</p>
                 <p className="text-3xl font-bold text-primary">{tasks.length}</p>
               </div>
               <div className="text-center p-4 bg-surface2 rounded-xl border border-border">
-                <p className="text-sm text-muted mb-2">Available Courses</p>
+                <p className="text-sm text-muted mb-2">{t("reports.availableCourses")}</p>
                 <p className="text-3xl font-bold text-primary">{courses.length}</p>
               </div>
               <div className="text-center p-4 bg-surface2 rounded-xl border border-border">
-                <p className="text-sm text-muted mb-2">Avg. Points</p>
+                <p className="text-sm text-muted mb-2">{t("reports.avgPoints")}</p>
                 <p className="text-3xl font-bold text-primary">
                   {interns.length > 0 ? Math.round(interns.reduce((sum, i) => sum + i.points, 0) / interns.length) : 0}
                 </p>

--- a/Ascenda Padrinho att/src/pages/VacationRequests.jsx
+++ b/Ascenda Padrinho att/src/pages/VacationRequests.jsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { motion } from "framer-motion";
 import VacationRequestsPanel from "../components/vacation/VacationRequestsPanel";
+import { useTranslation } from "@/i18n";
 
 export default function VacationRequests() {
+  const { t } = useTranslation();
   return (
     <div className="min-h-screen p-6 md:p-8">
       <div className="max-w-5xl mx-auto space-y-8">
@@ -11,9 +13,9 @@ export default function VacationRequests() {
           animate={{ opacity: 1, y: 0 }}
         >
           <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-            Vacation Requests
+            {t("vacation.title")}
           </h1>
-          <p className="text-muted">Review and manage intern vacation requests</p>
+          <p className="text-muted">{t("vacation.subtitle")}</p>
         </motion.div>
 
         <VacationRequestsPanel />


### PR DESCRIPTION
## Summary
- add a lightweight i18n provider with English and Portuguese dictionaries plus persistent language selection
- wrap the application layout with the language provider and expose a sidebar language toggle
- replace hardcoded strings across dashboard, reports, vacation, chat, and content flows with translation lookups

## Testing
- not run (npm install repeatedly failed in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfd1f70cf0832dbf882078dbf9caed