### PR TITLE
fix: ensure language provider parses under vite

### DIFF
--- a/Ascenda Padrinho att/src/App.jsx
+++ b/Ascenda Padrinho att/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 import Layout from './Layout.jsx';
 import Dashboard from './pages/Dashboard.jsx';
 import Interns from './pages/Interns.jsx';
@@ -8,20 +8,45 @@ import VacationRequests from './pages/VacationRequests.jsx';
 import Reports from './pages/Reports.jsx';
 import { PAGE_URLS } from './utils/index.js';
 
+const router = createBrowserRouter([
+  {
+    path: PAGE_URLS.Dashboard,
+    element: <Layout />,
+    children: [
+      {
+        index: true,
+        element: <Dashboard />,
+      },
+      {
+        path: PAGE_URLS.Interns.replace(/^\//, ''),
+        element: <Interns />,
+      },
+      {
+        path: PAGE_URLS.ContentManagement.replace(/^\//, ''),
+        element: <ContentManagement />,
+      },
+      {
+        path: PAGE_URLS.VacationRequests.replace(/^\//, ''),
+        element: <VacationRequests />,
+      },
+      {
+        path: PAGE_URLS.Reports.replace(/^\//, ''),
+        element: <Reports />,
+      },
+      {
+        path: '*',
+        element: <Navigate to={PAGE_URLS.Dashboard} replace />,
+      },
+    ],
+  },
+]);
+
 export default function App() {
   return (
-    <BrowserRouter>
-      <Layout>
-        <Routes>
-          <Route path={PAGE_URLS.Dashboard} element={<Dashboard />} />
-          <Route path={PAGE_URLS.Interns} element={<Interns />} />
-          <Route path={PAGE_URLS.ContentManagement} element={<ContentManagement />} />
-          <Route path={PAGE_URLS.VacationRequests} element={<VacationRequests />} />
-          <Route path={PAGE_URLS.Reports} element={<Reports />} />
-          <Route path="*" element={<Navigate to={PAGE_URLS.Dashboard} replace />} />
-        </Routes>
-      </Layout>
-    </BrowserRouter>
+    <RouterProvider
+      router={router}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    />
   );
 }
 

--- a/Ascenda Padrinho att/src/Layout.jsx
+++ b/Ascenda Padrinho att/src/Layout.jsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, Outlet, useLocation } from "react-router-dom";
 import { createPageUrl } from "@/utils";
-import { 
-  LayoutDashboard, 
-  Users, 
-  BookOpen, 
+import {
+  LayoutDashboard,
+  Users,
+  BookOpen,
   BarChart3,
   Calendar,
   Sparkles,
@@ -15,6 +15,8 @@ import { User } from "@/entities/User";
 import { ThemeProvider } from "./components/theme/ThemeProvider";
 import ThemeToggle from "./components/theme/ThemeToggle";
 import NotificationBell from "./components/notifications/NotificationBell";
+import LanguageToggle from "./components/i18n/LanguageToggle";
+import { useTranslation } from "./i18n";
 import {
   Sidebar,
   SidebarContent,
@@ -30,37 +32,38 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 
-const navigationItems = [
-  {
-    title: "Dashboard",
-    url: createPageUrl("Dashboard"),
-    icon: LayoutDashboard,
-  },
-  {
-    title: "Team Overview",
-    url: createPageUrl("Interns"),
-    icon: Users,
-  },
-  {
-    title: "Content Management",
-    url: createPageUrl("ContentManagement"),
-    icon: BookOpen,
-  },
-  {
-    title: "Vacation Requests",
-    url: createPageUrl("VacationRequests"),
-    icon: Calendar,
-  },
-  {
-    title: "Reports",
-    url: createPageUrl("Reports"),
-    icon: BarChart3,
-  },
-];
-
-function LayoutContent({ children }) {
+function LayoutContent() {
   const location = useLocation();
   const [user, setUser] = React.useState(null);
+  const { t } = useTranslation();
+
+  const navigationItems = React.useMemo(() => [
+    {
+      title: t("layout.navItems.dashboard", "Dashboard"),
+      url: createPageUrl("Dashboard"),
+      icon: LayoutDashboard,
+    },
+    {
+      title: t("layout.navItems.interns", "Team Overview"),
+      url: createPageUrl("Interns"),
+      icon: Users,
+    },
+    {
+      title: t("layout.navItems.content", "Content Management"),
+      url: createPageUrl("ContentManagement"),
+      icon: BookOpen,
+    },
+    {
+      title: t("layout.navItems.vacation", "Vacation Requests"),
+      url: createPageUrl("VacationRequests"),
+      icon: Calendar,
+    },
+    {
+      title: t("layout.navItems.reports", "Reports"),
+      url: createPageUrl("Reports"),
+      icon: BarChart3,
+    },
+  ], [t]);
 
   React.useEffect(() => {
     const loadUser = async () => {
@@ -202,8 +205,8 @@ function LayoutContent({ children }) {
                 </div>
               </div>
               <div>
-                <h2 className="font-bold text-primary">Ascenda</h2>
-                <p className="text-xs text-muted">Manager Portal</p>
+                <h2 className="font-bold text-primary">{t("layout.appName", "Ascenda")}</h2>
+                <p className="text-xs text-muted">{t("layout.subtitle", "Manager Portal")}</p>
               </div>
             </div>
           </SidebarHeader>
@@ -211,7 +214,7 @@ function LayoutContent({ children }) {
           <SidebarContent className="p-3">
             <SidebarGroup>
               <SidebarGroupLabel className="text-xs font-medium text-muted uppercase tracking-wider px-3 py-2">
-                Navigation
+                {t("layout.navigation", "Navigation")}
               </SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu>
@@ -241,8 +244,9 @@ function LayoutContent({ children }) {
           </SidebarContent>
 
           <SidebarFooter className="border-t border-border p-4 space-y-3">
-            <div className="flex gap-2">
+            <div className="flex items-center gap-2">
               <ThemeToggle />
+              <LanguageToggle />
               <NotificationBell />
             </div>
             {user && (
@@ -250,12 +254,12 @@ function LayoutContent({ children }) {
                 <div className="flex items-center gap-3 mb-3">
                   <div className="w-10 h-10 bg-gradient-to-br from-brand to-brand2 rounded-full flex items-center justify-center">
                     <span className="text-white font-bold text-sm">
-                      {user.full_name?.charAt(0) || 'M'}
+                      {user.full_name?.charAt(0) || t("layout.userFallback", "Manager").charAt(0)}
                     </span>
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className="font-semibold text-primary text-sm truncate">
-                      {user.full_name || 'Manager'}
+                      {user.full_name || t("layout.userFallback", "Manager")}
                     </p>
                     <p className="text-xs text-muted truncate">
                       {user.email}
@@ -269,7 +273,7 @@ function LayoutContent({ children }) {
                   className="w-full text-secondary hover:text-primary hover:bg-surface2"
                 >
                   <LogOut className="w-4 h-4 mr-2" />
-                  Logout
+                  {t("layout.logout", "Logout")}
                 </Button>
               </div>
             )}
@@ -288,7 +292,7 @@ function LayoutContent({ children }) {
           </header>
 
           <div className="flex-1 overflow-auto">
-            {children}
+            <Outlet />
           </div>
         </main>
       </div>
@@ -296,10 +300,10 @@ function LayoutContent({ children }) {
   );
 }
 
-export default function Layout({ children }) {
+export default function Layout() {
   return (
     <ThemeProvider>
-      <LayoutContent>{children}</LayoutContent>
+      <LayoutContent />
     </ThemeProvider>
   );
 }

--- a/Ascenda Padrinho att/src/components/dashboard/InternCard.jsx
+++ b/Ascenda Padrinho att/src/components/dashboard/InternCard.jsx
@@ -7,11 +7,13 @@ import { motion } from "framer-motion";
 import { LineChart, Line, ResponsiveContainer } from "recharts";
 import Avatar from "../ui/Avatar";
 import { getDaysLeft, getDaysLeftBadgeColor } from "../utils/dates";
+import { useTranslation } from "../../i18n";
 
 export default function InternCard({ intern, onClick, onChatClick, index }) {
   const avgScore = intern.performance_history?.length > 0
     ? intern.performance_history.reduce((sum, p) => sum + p.score, 0) / intern.performance_history.length
     : 0;
+  const { t } = useTranslation();
 
   const levelColors = {
     "Novice": "bg-gray-500/20 text-secondary border-border",
@@ -75,7 +77,7 @@ export default function InternCard({ intern, onClick, onChatClick, index }) {
                   {daysLeft !== null && daysLeftColors && (
                     <Badge className={`${daysLeftColors.bg} ${daysLeftColors.text} border ${daysLeftColors.border}`}>
                       <Calendar className="w-3 h-3 mr-1" />
-                      {daysLeft}d left
+                  {t('interns.card.daysLeft', '{{count}}d left', { count: daysLeft })}
                     </Badge>
                   )}
                 </div>
@@ -83,7 +85,7 @@ export default function InternCard({ intern, onClick, onChatClick, index }) {
               
               <div className="flex items-center gap-4 text-sm">
                 <div className="flex items-center gap-1">
-                  <span className="text-muted">Points:</span>
+                  <span className="text-muted">{t('interns.card.points', 'Points')}:</span>
                   <span className="font-bold text-brand2">
                     {intern.points}
                   </span>
@@ -92,7 +94,9 @@ export default function InternCard({ intern, onClick, onChatClick, index }) {
                   <div className="flex items-center gap-1">
                     <TrendingUp className="w-4 h-4 text-success" />
                     <span className="text-success font-medium">
-                      {avgScore.toFixed(0)}% avg
+                      {t('interns.card.avgScore', '{{value}}% avg', {
+                        value: avgScore.toFixed(0),
+                      })}
                     </span>
                   </div>
                 )}
@@ -135,7 +139,7 @@ export default function InternCard({ intern, onClick, onChatClick, index }) {
                 className="w-full mt-2 border-border hover:bg-surface2 text-secondary hover:text-primary"
               >
                 <MessageCircle className="w-4 h-4 mr-2" />
-                Chat
+                {t('interns.card.chat', 'Chat')}
               </Button>
             </div>
           </div>

--- a/Ascenda Padrinho att/src/components/dashboard/InternStatusCard.jsx
+++ b/Ascenda Padrinho att/src/components/dashboard/InternStatusCard.jsx
@@ -8,6 +8,7 @@ import { motion } from "framer-motion";
 import { RadialBarChart, RadialBar, ResponsiveContainer } from "recharts";
 import Avatar from "../ui/Avatar";
 import { getDaysLeft, getDaysLeftBadgeColor, getInternshipProgress } from "../utils/dates";
+import { useTranslation } from "../../i18n";
 
 const wellBeingVariants = {
   "Excellent": { icon: Smile, color: "text-success", bg: "bg-success/10" },
@@ -40,6 +41,7 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
   const wellBeing = wellBeingVariants[canonicalStatus] || wellBeingVariants["Neutral"];
   const WellBeingIcon = wellBeing.icon;
   const isActive = intern.status === 'active';
+  const { t } = useTranslation();
   
   const daysLeft = intern.end_date ? getDaysLeft(intern.end_date) : null;
   const daysLeftColors = daysLeft !== null ? getDaysLeftBadgeColor(daysLeft) : null;
@@ -88,7 +90,9 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
                   {intern.well_being_status && (
                     <div
                       className={`p-1.5 rounded-lg ${wellBeing.bg}`}
-                      title={`Well-being: ${canonicalStatus || intern.well_being_status || 'Unknown'}`}
+                      title={t('interns.card.progressTitle', 'Well-being: {{status}}', {
+                        status: canonicalStatus || intern.well_being_status || 'Unknown',
+                      })}
                     >
                       <WellBeingIcon className={`w-4 h-4 ${wellBeing.color}`} />
                     </div>
@@ -96,7 +100,7 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
                 </div>
                 <div className="flex items-center gap-2 text-sm flex-wrap">
                   <Badge variant="outline" className="bg-surface2 text-secondary border-border">
-                    {intern.track || 'Learning Track'}
+                    {intern.track || t('interns.card.trackFallback', 'Learning Track')}
                   </Badge>
                   <span className="text-muted">•</span>
                   <span className="text-muted">{intern.level}</span>
@@ -123,10 +127,12 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
                     </ResponsiveContainer>
                   </div>
                   <div className="flex-1">
-                    <p className="text-xs text-muted mb-1">Internship Progress</p>
+                    <p className="text-xs text-muted mb-1">
+                      {t('dashboard.status.progressLabel', 'Internship Progress')}
+                    </p>
                     <Badge className={`${daysLeftColors.bg} ${daysLeftColors.text} border ${daysLeftColors.border}`}>
                       <Calendar className="w-3 h-3 mr-1" />
-                      {daysLeft} days left
+                      {t('dashboard.status.daysLeft', '{{count}} days left', { count: daysLeft })}
                     </Badge>
                   </div>
                 </div>
@@ -134,11 +140,13 @@ export default function InternStatusCard({ intern, onStatusToggle, index }) {
 
               <div className="flex items-center justify-between pt-2 border-t border-border">
                 <Label htmlFor={`status-${intern.id}`} className="text-sm text-secondary cursor-pointer">
-                  System Status
+                  {t('dashboard.status.systemStatus', 'System Status')}
                 </Label>
                 <div className="flex items-center gap-2">
                   <span className={`text-sm font-medium ${isActive ? 'text-success' : 'text-warning'}`}>
-                    {isActive ? 'Active' : 'Paused'}
+                    {isActive
+                      ? t('dashboard.status.active', 'Active')
+                      : t('dashboard.status.paused', 'Paused')}
                   </span>
                   <Switch
                     id={`status-${intern.id}`}

--- a/Ascenda Padrinho att/src/components/dashboard/SummaryCard.jsx
+++ b/Ascenda Padrinho att/src/components/dashboard/SummaryCard.jsx
@@ -11,7 +11,7 @@ export default function SummaryCard({ title, value, icon: Icon, gradient, trend,
     >
       <Card className="border-border bg-surface hover:shadow-e2 transition-all duration-350 shadow-e1">
         <CardContent className="p-6">
-          <div className="flex items-start justify-between">
+          <div className="flex items-center justify-between">
             <div className="space-y-2">
               <p className="text-sm font-medium text-muted">{title}</p>
               <div className="flex items-baseline gap-2">
@@ -23,7 +23,7 @@ export default function SummaryCard({ title, value, icon: Icon, gradient, trend,
                 )}
               </div>
             </div>
-            <div className={`p-3 rounded-xl ${gradient} bg-opacity-20`}>
+            <div className={`flex h-12 w-12 items-center justify-center rounded-xl ${gradient} bg-opacity-20`}>
               <Icon className="w-6 h-6 text-brand" />
             </div>
           </div>

--- a/Ascenda Padrinho att/src/components/i18n/LanguageToggle.jsx
+++ b/Ascenda Padrinho att/src/components/i18n/LanguageToggle.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useTranslation } from '@/i18n';
+
+const options = [
+  { code: 'pt', emoji: '🇧🇷', label: 'Português' },
+  { code: 'en', emoji: '🇺🇸', label: 'English' },
+];
+
+export default function LanguageToggle() {
+  const { language, setLanguage } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-1 rounded-full border border-border bg-surface2/80 p-1">
+      {options.map((option) => {
+        const isActive = option.code === language;
+        return (
+          <button
+            key={option.code}
+            type="button"
+            onClick={() => setLanguage(option.code)}
+            className={`flex h-8 w-8 items-center justify-center rounded-full text-lg transition-colors ${
+              isActive
+                ? 'bg-surface shadow-e1 ring-2 ring-brand'
+                : 'hover:bg-surface/80 text-muted'
+            }`}
+            aria-label={option.label}
+            title={option.label}
+          >
+            <span aria-hidden="true">{option.emoji}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/Ascenda Padrinho att/src/components/reports/TaskCompletionChart.jsx
+++ b/Ascenda Padrinho att/src/components/reports/TaskCompletionChart.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from "recharts";
+import { useTranslation } from "../../i18n";
 
 const COLORS = {
   completed: 'var(--success)',
@@ -9,17 +10,19 @@ const COLORS = {
 };
 
 export default function TaskCompletionChart({ data }) {
+  const { t } = useTranslation();
+
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-muted">
-        <p>No task data available</p>
+        <p>{t('reports.charts.statuses.empty', 'No task data available')}</p>
       </div>
     );
   }
 
   const formattedData = data.map(item => ({
     ...item,
-    displayName: item.name.replace('_', ' ').charAt(0).toUpperCase() + item.name.replace('_', ' ').slice(1)
+    displayName: t(`reports.charts.statuses.${item.name}`, item.name.replace('_', ' '))
   }));
 
   return (

--- a/Ascenda Padrinho att/src/components/reports/TeamPerformanceChart.jsx
+++ b/Ascenda Padrinho att/src/components/reports/TeamPerformanceChart.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import { useTranslation } from "../../i18n";
 
 export default function TeamPerformanceChart({ data }) {
+  const { t } = useTranslation();
+
   if (!data || data.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-muted">
-        <p>No performance data available</p>
+        <p>{t('reports.charts.performanceEmpty', 'No performance data available')}</p>
       </div>
     );
   }
@@ -35,14 +38,14 @@ export default function TeamPerformanceChart({ data }) {
           labelStyle={{ color: 'var(--text-secondary)' }}
           cursor={{ fill: 'var(--surface-2)', opacity: 0.3 }}
         />
-        <Legend 
+        <Legend
           wrapperStyle={{ color: 'var(--text-secondary)' }}
         />
-        <Bar 
-          dataKey="points" 
-          fill="var(--brand)" 
+        <Bar
+          dataKey="points"
+          fill="var(--brand)"
           radius={[8, 8, 0, 0]}
-          name="Points"
+          name={t('reports.charts.legendPoints', 'Points')}
         />
       </BarChart>
     </ResponsiveContainer>

--- a/Ascenda Padrinho att/src/components/ui/sidebar.jsx
+++ b/Ascenda Padrinho att/src/components/ui/sidebar.jsx
@@ -28,15 +28,17 @@ function useSidebar() {
 export function Sidebar({ className, children }) {
   const { isOpen, setOpen } = useSidebar();
 
+  const widthClass = 'w-64';
+
   const content = (
-    <nav className={cn('flex h-full w-72 flex-col bg-surface', className)}>{children}</nav>
+    <nav className={cn(`flex h-full ${widthClass} flex-col bg-surface`, className)}>{children}</nav>
   );
 
   return (
     <>
-      <div className="hidden h-screen w-72 flex-shrink-0 md:flex">{content}</div>
+      <div className={`hidden h-screen ${widthClass} flex-shrink-0 md:flex`}>{content}</div>
       <div className={cn('fixed inset-0 z-40 bg-black/40 transition-opacity md:hidden', isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none')} onClick={() => setOpen(false)} />
-      <div className={cn('fixed inset-y-0 left-0 z-50 w-72 max-w-full transform bg-surface shadow-e3 transition-transform md:hidden', isOpen ? 'translate-x-0' : '-translate-x-full')}>
+      <div className={cn(`fixed inset-y-0 left-0 z-50 ${widthClass} max-w-full transform bg-surface shadow-e3 transition-transform md:hidden`, isOpen ? 'translate-x-0' : '-translate-x-full')}>
         {content}
       </div>
     </>

--- a/Ascenda Padrinho att/src/components/vacation/VacationRequestsPanel.jsx
+++ b/Ascenda Padrinho att/src/components/vacation/VacationRequestsPanel.jsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -23,10 +24,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Check, X, Calendar, CalendarCheck, AlertCircle } from "lucide-react";
+import { Check, X, Calendar, CalendarCheck, AlertCircle, Pencil } from "lucide-react";
 import { format } from "date-fns";
 import { eventBus, EventTypes } from "../utils/eventBus";
 import VacationCalendar from "./VacationCalendar";
+import Avatar from "@/components/ui/Avatar";
+import { useTranslation } from "../../i18n";
 
 export default function VacationRequestsPanel() {
   const [requests, setRequests] = useState([]);
@@ -36,6 +39,10 @@ export default function VacationRequestsPanel() {
   const [rejectDialog, setRejectDialog] = useState(null);
   const [managerNote, setManagerNote] = useState("");
   const [user, setUser] = useState(null);
+  const [emojiEditor, setEmojiEditor] = useState(null);
+  const [emojiValue, setEmojiValue] = useState("");
+  const [isUpdatingEmoji, setIsUpdatingEmoji] = useState(false);
+  const { t } = useTranslation();
 
   const loadData = useCallback(async () => {
     const [requestsData, internsData] = await Promise.all([
@@ -66,6 +73,46 @@ export default function VacationRequestsPanel() {
     return Object.fromEntries(interns.map(i => [i.id, i]));
   }, [interns]);
 
+  const openEmojiEditor = useCallback((intern) => {
+    if (!intern) return;
+    setEmojiEditor(intern);
+    setEmojiValue(intern.avatar_url || "");
+  }, []);
+
+  const closeEmojiEditor = useCallback(() => {
+    setEmojiEditor(null);
+    setEmojiValue("");
+    setIsUpdatingEmoji(false);
+  }, []);
+
+  const saveEmoji = useCallback(async () => {
+    if (!emojiEditor || isUpdatingEmoji) return;
+
+    const nextValue = emojiValue.trim();
+    const currentValue = emojiEditor.avatar_url || '';
+    if (nextValue === currentValue) {
+      return;
+    }
+
+    setIsUpdatingEmoji(true);
+
+    try {
+      await Intern.update(emojiEditor.id, { avatar_url: nextValue || null });
+      setInterns((prev) =>
+        prev.map((item) =>
+          String(item.id) === String(emojiEditor.id)
+            ? { ...item, avatar_url: nextValue || null }
+            : item
+        )
+      );
+      closeEmojiEditor();
+    } catch (error) {
+      console.error('Error updating emoji:', error);
+    } finally {
+      setIsUpdatingEmoji(false);
+    }
+  }, [emojiEditor, emojiValue, isUpdatingEmoji, closeEmojiEditor]);
+
   const handleApprove = useCallback(async (request) => {
     if (processingId) return;
     
@@ -79,11 +126,14 @@ export default function VacationRequestsPanel() {
       const intern = internsById[request.intern_id];
       await Notification.create({
         type: 'vacation_status_changed',
-        title: 'Vacation Request Approved',
-        body: `Your vacation request from ${format(new Date(request.start_date), 'MMM d')} to ${format(new Date(request.end_date), 'MMM d')} has been approved.`,
+        title: t('vacations.panel.notifications.approvedTitle', 'Vacation Request Approved'),
+        body: t('vacations.panel.notifications.approvedBody', 'Your vacation request from {{start}} to {{end}} has been approved.', {
+          start: format(new Date(request.start_date), 'MMM d'),
+          end: format(new Date(request.end_date), 'MMM d'),
+        }),
         target_id: request.id,
         target_kind: 'request',
-        actor_name: user?.full_name || 'Manager'
+        actor_name: user?.full_name || t('layout.userFallback', 'Manager')
       });
 
       eventBus.emit(EventTypes.VACATION_STATUS_CHANGED, {
@@ -117,11 +167,14 @@ export default function VacationRequestsPanel() {
       const intern = internsById[rejectDialog.intern_id];
       await Notification.create({
         type: 'vacation_status_changed',
-        title: 'Vacation Request Rejected',
-        body: `Your vacation request from ${format(new Date(rejectDialog.start_date), 'MMM d')} to ${format(new Date(rejectDialog.end_date), 'MMM d')} has been rejected.${managerNote ? ` Note: ${managerNote}` : ''}`,
+        title: t('vacations.panel.notifications.rejectedTitle', 'Vacation Request Rejected'),
+        body: `${t('vacations.panel.notifications.rejectedBody', 'Your vacation request from {{start}} to {{end}} has been rejected.', {
+          start: format(new Date(rejectDialog.start_date), 'MMM d'),
+          end: format(new Date(rejectDialog.end_date), 'MMM d'),
+        })}${managerNote ? t('vacations.panel.notifications.noteSuffix', ' Note: {{note}}', { note: managerNote }) : ''}`,
         target_id: rejectDialog.id,
         target_kind: 'request',
-        actor_name: user?.full_name || 'Manager'
+        actor_name: user?.full_name || t('layout.userFallback', 'Manager')
       });
 
       eventBus.emit(EventTypes.VACATION_STATUS_CHANGED, {
@@ -150,13 +203,19 @@ export default function VacationRequestsPanel() {
     rejected: "bg-red-500/20 text-error border-red-500/30"
   };
 
+  const trimmedEmojiValue = emojiValue.trim();
+  const previewEmoji = trimmedEmojiValue || emojiEditor?.avatar_url || '👤';
+  const emojiHasChanges = emojiEditor
+    ? trimmedEmojiValue !== (emojiEditor.avatar_url || '')
+    : Boolean(trimmedEmojiValue);
+
   return (
     <>
       <Card className="border-border bg-surface shadow-e1">
         <CardHeader>
           <CardTitle className="text-primary flex items-center gap-2">
             <Calendar className="w-5 h-5" />
-            Vacation Requests
+            {t('vacations.panel.heading', 'Vacation Requests')}
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -164,11 +223,11 @@ export default function VacationRequestsPanel() {
             <TabsList className="mb-6 bg-surface2">
               <TabsTrigger value="list" className="data-[state=active]:bg-surface">
                 <CalendarCheck className="w-4 h-4 mr-2" />
-                Requests List
+                {t('vacations.panel.tabs.list', 'Requests List')}
               </TabsTrigger>
               <TabsTrigger value="calendar" className="data-[state=active]:bg-surface">
                 <Calendar className="w-4 h-4 mr-2" />
-                Calendar View
+                {t('vacations.panel.tabs.calendar', 'Calendar View')}
               </TabsTrigger>
             </TabsList>
 
@@ -176,17 +235,19 @@ export default function VacationRequestsPanel() {
               <div className="flex items-center justify-between mb-4">
                 <Select value={filterStatus} onValueChange={setFilterStatus}>
                   <SelectTrigger className="w-40 bg-surface2 border-border text-primary">
-                    <SelectValue placeholder="Filter" />
+                    <SelectValue placeholder={t('vacations.panel.filterPlaceholder', 'Filter')} />
                   </SelectTrigger>
                   <SelectContent className="bg-surface border-border">
-                    <SelectItem value="all">All Requests</SelectItem>
-                    <SelectItem value="pending">Pending</SelectItem>
-                    <SelectItem value="approved">Approved</SelectItem>
-                    <SelectItem value="rejected">Rejected</SelectItem>
+                    <SelectItem value="all">{t('vacations.panel.filters.all', 'All Requests')}</SelectItem>
+                    <SelectItem value="pending">{t('vacations.panel.filters.pending', 'Pending')}</SelectItem>
+                    <SelectItem value="approved">{t('vacations.panel.filters.approved', 'Approved')}</SelectItem>
+                    <SelectItem value="rejected">{t('vacations.panel.filters.rejected', 'Rejected')}</SelectItem>
                   </SelectContent>
                 </Select>
                 <span className="text-sm text-muted">
-                  {filteredRequests.length} request{filteredRequests.length !== 1 ? 's' : ''}
+                  {filteredRequests.length === 1
+                    ? t('vacations.panel.count.one', '1 request')
+                    : t('vacations.panel.count.other', '{{count}} requests', { count: filteredRequests.length })}
                 </span>
               </div>
 
@@ -194,16 +255,43 @@ export default function VacationRequestsPanel() {
                 {filteredRequests.map((request) => {
                   const intern = internsById[request.intern_id];
                   const isPending = request.status === 'pending';
-                  
+
                   return (
                     <article
                       key={request.id}
                       className="p-4 rounded-xl border border-border bg-surface2 hover:shadow-e1 transition-all"
-                      aria-label={`Vacation request from ${intern?.full_name || 'Unknown'}`}
+                      aria-label={t('vacations.panel.aria.listItem', 'Vacation request from {{name}}', {
+                        name: intern?.full_name || 'Unknown',
+                      })}
                     >
                       <div className="grid grid-cols-[auto,1fr,auto] gap-4 items-start">
-                        <div className="w-12 h-12 rounded-full bg-gradient-to-br from-brand to-brand2 flex items-center justify-center text-2xl flex-shrink-0">
-                          {intern?.avatar_url || '👤'}
+                        <div className="relative flex-shrink-0">
+                          {intern ? (
+                            <>
+                              <button
+                                type="button"
+                                onClick={() => openEmojiEditor(intern)}
+                                className="w-12 h-12 rounded-full bg-gradient-to-br from-brand to-brand2 flex items-center justify-center text-2xl transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                                title={t('vacations.panel.aria.updateEmoji', 'Update profile emoji for {{name}}', {
+                                  name: intern.full_name,
+                                })}
+                              >
+                                {intern.avatar_url || '👤'}
+                                <span className="sr-only">
+                                  {t('vacations.panel.aria.updateEmoji', 'Update profile emoji for {{name}}', {
+                                    name: intern.full_name,
+                                  })}
+                                </span>
+                              </button>
+                              <span className="absolute -bottom-1 -right-1 rounded-full bg-surface text-muted border border-border p-1 shadow-sm">
+                                <Pencil className="w-3 h-3" aria-hidden="true" />
+                              </span>
+                            </>
+                          ) : (
+                            <div className="w-12 h-12 rounded-full bg-gradient-to-br from-brand to-brand2 flex items-center justify-center text-2xl">
+                              {'👤'}
+                            </div>
+                          )}
                         </div>
                         
                         <div className="min-w-0">
@@ -212,39 +300,41 @@ export default function VacationRequestsPanel() {
                               {intern?.full_name || 'Unknown'}
                             </h3>
                             <Badge className={`${statusColors[request.status]} border capitalize flex-shrink-0`}>
-                              {request.status}
+                              {t(`vacations.panel.filters.${request.status}`, request.status)}
                             </Badge>
                           </div>
-                          
+
                           {intern && (
-                            <p className="text-xs text-muted mb-2">{intern.track}</p>
+                            <p className="text-xs text-muted mb-2">{intern.track || t('vacations.panel.fields.trackFallback', 'Learning track')}</p>
                           )}
-                          
+
                           <div className="space-y-1 text-sm">
                             <p className="text-secondary">
-                              <span className="text-muted">From:</span>{' '}
+                              <span className="text-muted">{t('vacations.panel.fields.from', 'From')}:</span>{' '}
                               <span className="font-medium">
                                 {format(new Date(request.start_date), 'MMM d, yyyy')}
                               </span>
                             </p>
                             <p className="text-secondary">
-                              <span className="text-muted">To:</span>{' '}
+                              <span className="text-muted">{t('vacations.panel.fields.to', 'To')}:</span>{' '}
                               <span className="font-medium">
                                 {format(new Date(request.end_date), 'MMM d, yyyy')}
                               </span>
                             </p>
                             {request.reason && (
                               <p className="text-secondary mt-2">
-                                <span className="text-muted">Reason:</span> {request.reason}
+                                <span className="text-muted">{t('vacations.panel.fields.reason', 'Reason')}:</span> {request.reason}
                               </p>
                             )}
                             {request.manager_note && (
                               <p className="text-secondary mt-2 p-2 bg-surface rounded border border-border">
-                                <span className="text-muted">Manager note:</span> {request.manager_note}
+                                <span className="text-muted">{t('vacations.panel.fields.managerNote', 'Manager note:')}</span> {request.manager_note}
                               </p>
                             )}
                             <p className="text-xs text-muted mt-2">
-                              Requested {format(new Date(request.created_date), 'MMM d, yyyy')}
+                              {t('vacations.panel.fields.requestedOn', 'Requested {{date}}', {
+                                date: format(new Date(request.created_date), 'MMM d, yyyy'),
+                              })}
                             </p>
                           </div>
                         </div>
@@ -256,10 +346,12 @@ export default function VacationRequestsPanel() {
                               onClick={() => handleApprove(request)}
                               disabled={processingId === request.id}
                               className="bg-success hover:bg-success/90 text-white font-medium"
-                              aria-label={`Approve vacation request for ${intern?.full_name}`}
+                              aria-label={t('vacations.panel.aria.approve', 'Approve vacation request for {{name}}', {
+                                name: intern?.full_name,
+                              })}
                             >
                               <Check className="w-4 h-4 mr-1" />
-                              Approve
+                              {t('vacations.panel.actions.approve', 'Approve')}
                             </Button>
                             <Button
                               size="sm"
@@ -267,10 +359,12 @@ export default function VacationRequestsPanel() {
                               onClick={() => handleReject(request)}
                               disabled={processingId === request.id}
                               className="border-error text-error hover:bg-error/10 font-medium"
-                              aria-label={`Reject vacation request for ${intern?.full_name}`}
+                              aria-label={t('vacations.panel.aria.reject', 'Reject vacation request for {{name}}', {
+                                name: intern?.full_name,
+                              })}
                             >
                               <X className="w-4 h-4 mr-1" />
-                              Reject
+                              {t('vacations.panel.actions.reject', 'Reject')}
                             </Button>
                           </div>
                         )}
@@ -282,7 +376,7 @@ export default function VacationRequestsPanel() {
                 {filteredRequests.length === 0 && (
                   <div className="text-center py-12 bg-surface2 rounded-xl border border-border">
                     <AlertCircle className="w-12 h-12 mx-auto mb-3 text-muted opacity-50" />
-                    <p className="text-muted">No vacation requests found</p>
+                    <p className="text-muted">{t('vacations.panel.empty', 'No vacation requests found')}</p>
                   </div>
                 )}
               </div>
@@ -298,24 +392,101 @@ export default function VacationRequestsPanel() {
         </CardContent>
       </Card>
 
+      <Dialog
+        open={!!emojiEditor}
+        onOpenChange={(open) => {
+          if (!open && !isUpdatingEmoji) {
+            closeEmojiEditor();
+          }
+        }}
+      >
+        <DialogContent className="bg-surface border-border max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-primary">
+              {t('vacations.panel.emojiDialog.title', 'Update Profile Emoji')}
+            </DialogTitle>
+            <DialogDescription className="text-secondary">
+              {t('vacations.panel.emojiDialog.description', 'Choose an emoji or paste an image URL for {{name}}.', {
+                name: emojiEditor?.full_name,
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="w-14 h-14 rounded-full bg-gradient-to-br from-brand to-brand2 p-0.5">
+                <div className="w-full h-full rounded-full bg-surface flex items-center justify-center overflow-hidden">
+                  <Avatar
+                    src={previewEmoji}
+                    alt={emojiEditor?.full_name || 'Intern avatar preview'}
+                    size={56}
+                  />
+                </div>
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm text-secondary">
+                  {t('vacations.panel.emojiDialog.previewLabel', 'Preview')}
+                </p>
+                <p className="text-base font-semibold text-primary truncate max-w-[180px]">
+                  {emojiEditor?.full_name || 'Intern'}
+                </p>
+              </div>
+            </div>
+
+            <Input
+              value={emojiValue}
+              onChange={(e) => setEmojiValue(e.target.value)}
+              placeholder={t('vacations.panel.emojiDialog.placeholder', 'Try 😀 or paste an image URL')}
+              className="bg-surface2 border-border text-primary"
+            />
+            <p className="text-xs text-muted">
+              {t('vacations.panel.emojiDialog.helper', 'Emojis render beautifully across the app and you can swap them anytime. Image URLs are also supported.')}
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (!isUpdatingEmoji) {
+                  closeEmojiEditor();
+                }
+              }}
+              className="border-border"
+            >
+              {t('common.cancel', 'Cancel')}
+            </Button>
+            <Button
+              onClick={saveEmoji}
+              disabled={!emojiHasChanges || isUpdatingEmoji}
+              className="bg-brand hover:bg-brand/90 text-white font-medium"
+            >
+              {t('vacations.panel.actions.saveEmoji', 'Save Emoji')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Dialog open={!!rejectDialog} onOpenChange={() => setRejectDialog(null)}>
         <DialogContent className="bg-surface border-border">
           <DialogHeader>
-            <DialogTitle className="text-primary">Reject Vacation Request</DialogTitle>
+            <DialogTitle className="text-primary">
+              {t('vacations.panel.rejectDialog.title', 'Reject Vacation Request')}
+            </DialogTitle>
             <DialogDescription className="text-secondary">
-              Are you sure you want to reject this vacation request? You can optionally add a note.
+              {t('vacations.panel.rejectDialog.description', 'Are you sure you want to reject this vacation request? You can optionally add a note.')}
             </DialogDescription>
           </DialogHeader>
-          
+
           <div className="space-y-4">
             <div>
               <label className="text-sm font-medium text-secondary mb-2 block">
-                Manager Note (Optional)
+                {t('vacations.panel.rejectDialog.noteLabel', 'Manager Note (Optional)')}
               </label>
               <Textarea
                 value={managerNote}
                 onChange={(e) => setManagerNote(e.target.value)}
-                placeholder="Explain the reason for rejection..."
+                placeholder={t('vacations.panel.rejectDialog.notePlaceholder', 'Explain the reason for rejection...')}
                 className="bg-surface2 border-border text-primary"
                 rows={3}
               />
@@ -328,7 +499,7 @@ export default function VacationRequestsPanel() {
               onClick={() => setRejectDialog(null)}
               className="border-border"
             >
-              Cancel
+              {t('common.cancel', 'Cancel')}
             </Button>
             <Button
               onClick={confirmReject}
@@ -336,7 +507,7 @@ export default function VacationRequestsPanel() {
               className="bg-error hover:bg-error/90 text-white font-medium"
             >
               <X className="w-4 h-4 mr-2" />
-              Reject Request
+              {t('vacations.panel.actions.rejectRequest', 'Reject Request')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/Ascenda Padrinho att/src/entities/ChatMessage.js
+++ b/Ascenda Padrinho att/src/entities/ChatMessage.js
@@ -1,7 +1,9 @@
 import { createEntityStore } from './store';
-import { chatMessages as initialMessages } from './data';
+import { chatMessages as initialMessages, seedDataVersion } from './data';
 
-const store = createEntityStore('ascenda_chat_messages', initialMessages);
+const store = createEntityStore('ascenda_chat_messages', initialMessages, {
+  version: seedDataVersion,
+});
 
 export const ChatMessage = {
   list(sort, limit) {

--- a/Ascenda Padrinho att/src/entities/Course.js
+++ b/Ascenda Padrinho att/src/entities/Course.js
@@ -1,7 +1,9 @@
 import { createEntityStore } from './store';
-import { courses as initialCourses } from './data';
+import { courses as initialCourses, seedDataVersion } from './data';
 
-const store = createEntityStore('ascenda_courses', initialCourses);
+const store = createEntityStore('ascenda_courses', initialCourses, {
+  version: seedDataVersion,
+});
 
 export const Course = {
   list(sort, limit) {

--- a/Ascenda Padrinho att/src/entities/CourseAssignment.js
+++ b/Ascenda Padrinho att/src/entities/CourseAssignment.js
@@ -1,7 +1,9 @@
 import { createEntityStore } from './store';
-import { courseAssignments as initialAssignments } from './data';
+import { courseAssignments as initialAssignments, seedDataVersion } from './data';
 
-const store = createEntityStore('ascenda_course_assignments', initialAssignments);
+const store = createEntityStore('ascenda_course_assignments', initialAssignments, {
+  version: seedDataVersion,
+});
 
 export const CourseAssignment = {
   list(sort, limit) {

--- a/Ascenda Padrinho att/src/entities/Intern.js
+++ b/Ascenda Padrinho att/src/entities/Intern.js
@@ -1,7 +1,9 @@
 import { createEntityStore } from './store';
-import { interns as initialInterns } from './data';
+import { interns as initialInterns, seedDataVersion } from './data';
 
-const store = createEntityStore('ascenda_interns', initialInterns);
+const store = createEntityStore('ascenda_interns', initialInterns, {
+  version: seedDataVersion,
+});
 
 export const Intern = {
   list(sort, limit) {

--- a/Ascenda Padrinho att/src/entities/Notification.js
+++ b/Ascenda Padrinho att/src/entities/Notification.js
@@ -1,7 +1,9 @@
 import { createEntityStore } from './store';
-import { notifications as initialNotifications } from './data';
+import { notifications as initialNotifications, seedDataVersion } from './data';
 
-const store = createEntityStore('ascenda_notifications', initialNotifications);
+const store = createEntityStore('ascenda_notifications', initialNotifications, {
+  version: seedDataVersion,
+});
 
 export const Notification = {
   list(sort, limit) {

--- a/Ascenda Padrinho att/src/entities/Task.js
+++ b/Ascenda Padrinho att/src/entities/Task.js
@@ -1,7 +1,9 @@
 import { createEntityStore } from './store';
-import { tasks as initialTasks } from './data';
+import { tasks as initialTasks, seedDataVersion } from './data';
 
-const store = createEntityStore('ascenda_tasks', initialTasks);
+const store = createEntityStore('ascenda_tasks', initialTasks, {
+  version: seedDataVersion,
+});
 
 export const Task = {
   list(sort, limit) {

--- a/Ascenda Padrinho att/src/entities/VacationRequest.js
+++ b/Ascenda Padrinho att/src/entities/VacationRequest.js
@@ -1,7 +1,9 @@
 import { createEntityStore } from './store';
-import { vacationRequests as initialRequests } from './data';
+import { vacationRequests as initialRequests, seedDataVersion } from './data';
 
-const store = createEntityStore('ascenda_vacation_requests', initialRequests);
+const store = createEntityStore('ascenda_vacation_requests', initialRequests, {
+  version: seedDataVersion,
+});
 
 export const VacationRequest = {
   list(sort, limit) {

--- a/Ascenda Padrinho att/src/entities/data.js
+++ b/Ascenda Padrinho att/src/entities/data.js
@@ -1,3 +1,5 @@
+export const seedDataVersion = '2024-10-07-roster';
+
 export const users = [
   {
     id: 1,
@@ -9,97 +11,133 @@ export const users = [
 
 export const interns = [
   {
-    id: 1,
-    full_name: 'Lucas Almeida',
-    avatar_url: 'https://avatars.dicebear.com/api/avataaars/lucas-almeida.svg',
-    email: 'lucas.almeida@ascenda.com',
+    id: 'caio',
+    full_name: 'Caio Menezes',
+    avatar: '/avatars/caio.jpg',
+    avatar_url: '🧑‍💻',
+    email: 'caio.menezes@ascenda.com',
     level: 'Journeyman',
     status: 'active',
-    track: 'Front-end Engineering',
-    cohort: '2024.1',
-    mentor_name: 'Ana Ribeiro',
+    track: 'JavaScript + React',
+    cohort: '2024.2',
+    mentor_name: 'Helena Prado',
     points: 820,
-    well_being_status: 'green',
-    start_date: '2024-02-01T00:00:00.000Z',
-    end_date: '2024-11-30T00:00:00.000Z',
-    skills: ['React', 'TypeScript', 'UX'],
+    avg_score_pct: 84,
+    well_being_status: 'Good',
+    start_date: '2024-02-05T00:00:00.000Z',
+    end_date: '2024-12-20T00:00:00.000Z',
+    skills: ['JavaScript', 'React'],
     performance_history: [
-      { date: '2024-03-01', score: 72 },
-      { date: '2024-04-01', score: 78 },
-      { date: '2024-05-01', score: 82 },
-      { date: '2024-06-01', score: 85 },
+      { date: '2024-03-01', score: 78 },
+      { date: '2024-04-01', score: 82 },
+      { date: '2024-05-01', score: 84 },
+      { date: '2024-06-01', score: 86 },
       { date: '2024-07-01', score: 88 },
       { date: '2024-08-01', score: 90 }
     ]
   },
   {
-    id: 2,
-    full_name: 'Carla Mendes',
-    avatar_url: 'https://avatars.dicebear.com/api/avataaars/carla-mendes.svg',
-    email: 'carla.mendes@ascenda.com',
+    id: 'gabriela',
+    full_name: 'Gabriela Gomes',
+    avatar: '/avatars/gabriela.jpg',
+    avatar_url: '🗂️',
+    email: 'gabriela.gomes@ascenda.com',
     level: 'Apprentice',
     status: 'active',
-    track: 'Data Analytics',
-    cohort: '2024.1',
+    track: 'SAP + PMO',
+    cohort: '2024.2',
     mentor_name: 'João Freitas',
-    points: 640,
-    well_being_status: 'yellow',
-    start_date: '2024-01-15T00:00:00.000Z',
-    end_date: '2024-10-15T00:00:00.000Z',
-    skills: ['SQL', 'Python', 'Storytelling'],
+    points: 610,
+    avg_score_pct: 78,
+    well_being_status: 'Neutral',
+    start_date: '2024-03-11T00:00:00.000Z',
+    end_date: '2025-01-17T00:00:00.000Z',
+    skills: ['SAP', 'PMO'],
     performance_history: [
-      { date: '2024-03-01', score: 65 },
-      { date: '2024-04-01', score: 68 },
-      { date: '2024-05-01', score: 70 },
+      { date: '2024-03-01', score: 70 },
+      { date: '2024-04-01', score: 74 },
+      { date: '2024-05-01', score: 77 },
+      { date: '2024-06-01', score: 78 },
+      { date: '2024-07-01', score: 79 },
+      { date: '2024-08-01', score: 82 }
+    ]
+  },
+  {
+    id: 'ana',
+    full_name: 'Ana Carolina',
+    avatar: '/avatars/ana.jpg',
+    avatar_url: '🧾',
+    email: 'ana.carolina@ascenda.com',
+    level: 'Apprentice',
+    status: 'paused',
+    track: 'SAP + PMO',
+    cohort: '2024.2',
+    mentor_name: 'João Freitas',
+    points: 595,
+    avg_score_pct: 75,
+    well_being_status: 'Neutral',
+    start_date: '2024-04-01T00:00:00.000Z',
+    end_date: '2025-02-14T00:00:00.000Z',
+    skills: ['SAP', 'PMO'],
+    performance_history: [
+      { date: '2024-04-01', score: 70 },
+      { date: '2024-05-01', score: 72 },
       { date: '2024-06-01', score: 74 },
       { date: '2024-07-01', score: 76 },
-      { date: '2024-08-01', score: 79 }
+      { date: '2024-08-01', score: 78 },
+      { date: '2024-09-01', score: 80 }
     ]
   },
   {
-    id: 3,
-    full_name: 'Pedro Silva',
-    avatar_url: 'https://avatars.dicebear.com/api/avataaars/pedro-silva.svg',
-    email: 'pedro.silva@ascenda.com',
-    level: 'Expert',
-    status: 'active',
-    track: 'Product Design',
-    cohort: '2023.2',
-    mentor_name: 'Helena Prado',
-    points: 950,
-    well_being_status: 'green',
-    start_date: '2023-11-01T00:00:00.000Z',
-    end_date: '2024-09-15T00:00:00.000Z',
-    skills: ['Figma', 'Design Systems', 'User Research'],
-    performance_history: [
-      { date: '2024-03-01', score: 85 },
-      { date: '2024-04-01', score: 87 },
-      { date: '2024-05-01', score: 90 },
-      { date: '2024-06-01', score: 92 },
-      { date: '2024-07-01', score: 94 },
-      { date: '2024-08-01', score: 95 }
-    ]
-  },
-  {
-    id: 4,
-    full_name: 'Ana Bezerra',
-    avatar_url: 'https://avatars.dicebear.com/api/avataaars/ana-bezerra.svg',
-    email: 'ana.bezerra@ascenda.com',
+    id: 'leticia',
+    full_name: 'Leticia Alvez',
+    avatar: '/avatars/leticia.jpg',
+    avatar_url: '📊',
+    email: 'leticia.alvez@ascenda.com',
     level: 'Novice',
-    status: 'paused',
-    track: 'Customer Success',
-    cohort: '2024.2',
-    mentor_name: 'Rodrigo Serra',
-    points: 410,
-    well_being_status: 'red',
-    start_date: '2024-04-10T00:00:00.000Z',
-    end_date: '2025-01-15T00:00:00.000Z',
-    skills: ['Support', 'Empathy', 'Communication'],
+    status: 'active',
+    track: 'Power BI',
+    cohort: '2024.3',
+    mentor_name: 'Marina Costa',
+    points: 510,
+    avg_score_pct: 71,
+    well_being_status: 'Neutral',
+    start_date: '2024-05-06T00:00:00.000Z',
+    end_date: '2025-03-28T00:00:00.000Z',
+    skills: ['Power BI'],
     performance_history: [
-      { date: '2024-05-01', score: 52 },
-      { date: '2024-06-01', score: 55 },
-      { date: '2024-07-01', score: 58 },
-      { date: '2024-08-01', score: 60 }
+      { date: '2024-05-01', score: 64 },
+      { date: '2024-06-01', score: 68 },
+      { date: '2024-07-01', score: 70 },
+      { date: '2024-08-01', score: 72 },
+      { date: '2024-09-01', score: 73 },
+      { date: '2024-10-01', score: 75 }
+    ]
+  },
+  {
+    id: 'lucas',
+    full_name: 'Lucas Oliveira',
+    avatar: '/avatars/lucas.jpg',
+    avatar_url: '🤖',
+    email: 'lucas.oliveira@ascenda.com',
+    level: 'Journeyman',
+    status: 'active',
+    track: 'AI + Python',
+    cohort: '2024.1',
+    mentor_name: 'Ana Ribeiro',
+    points: 670,
+    avg_score_pct: 80,
+    well_being_status: 'Excellent',
+    start_date: '2024-02-19T00:00:00.000Z',
+    end_date: '2024-12-06T00:00:00.000Z',
+    skills: ['Python', 'AI'],
+    performance_history: [
+      { date: '2024-03-01', score: 76 },
+      { date: '2024-04-01', score: 79 },
+      { date: '2024-05-01', score: 81 },
+      { date: '2024-06-01', score: 83 },
+      { date: '2024-07-01', score: 85 },
+      { date: '2024-08-01', score: 87 }
     ]
   }
 ];
@@ -150,7 +188,7 @@ export const courses = [
 export const courseAssignments = [
   {
     id: 1,
-    intern_id: 1,
+    intern_id: 'caio',
     course_id: 1,
     status: 'in_progress',
     progress: 55,
@@ -161,7 +199,7 @@ export const courseAssignments = [
   },
   {
     id: 2,
-    intern_id: 2,
+    intern_id: 'gabriela',
     course_id: 2,
     status: 'assigned',
     progress: 0,
@@ -171,8 +209,8 @@ export const courseAssignments = [
   },
   {
     id: 3,
-    intern_id: 3,
-    course_id: 1,
+    intern_id: 'lucas',
+    course_id: 3,
     status: 'completed',
     progress: 100,
     assigned_by: 'marina.costa@ascenda.com',
@@ -185,38 +223,45 @@ export const courseAssignments = [
 export const tasks = [
   {
     id: 1,
-    intern_id: 1,
+    intern_id: 'caio',
     title: 'Ship performance audit',
     status: 'completed',
     due_date: '2024-07-15T00:00:00.000Z'
   },
   {
     id: 2,
-    intern_id: 1,
+    intern_id: 'caio',
     title: 'Refine onboarding flows',
     status: 'in_progress',
     due_date: '2024-09-01T00:00:00.000Z'
   },
   {
     id: 3,
-    intern_id: 2,
+    intern_id: 'gabriela',
     title: 'Customer feedback analysis',
     status: 'pending',
     due_date: '2024-08-28T00:00:00.000Z'
   },
   {
     id: 4,
-    intern_id: 3,
-    title: 'Design system accessibility review',
-    status: 'completed',
-    due_date: '2024-06-30T00:00:00.000Z'
+    intern_id: 'ana',
+    title: 'PMO cadence deck refresh',
+    status: 'in_progress',
+    due_date: '2024-09-05T00:00:00.000Z'
   },
   {
     id: 5,
-    intern_id: 4,
-    title: 'CS playbook iteration',
+    intern_id: 'leticia',
+    title: 'Power BI revenue dashboard',
     status: 'pending',
     due_date: '2024-09-10T00:00:00.000Z'
+  },
+  {
+    id: 6,
+    intern_id: 'lucas',
+    title: 'Prototype AI assistant workflow',
+    status: 'completed',
+    due_date: '2024-08-01T00:00:00.000Z'
   }
 ];
 
@@ -225,7 +270,7 @@ export const notifications = [
     id: 1,
     type: 'course_assigned',
     title: 'New Course Assigned',
-    body: 'Lucas Almeida received "React Performance Masterclass".',
+    body: 'Caio Menezes received "React Performance Masterclass".',
     target_id: 1,
     target_kind: 'course',
     actor_name: 'Marina Costa',
@@ -236,7 +281,7 @@ export const notifications = [
     id: 2,
     type: 'vacation_status_changed',
     title: 'Vacation Request Approved',
-    body: 'Pedro Silva will be on vacation from Aug 21 to Aug 25.',
+    body: 'Gabriela Gomes will be on vacation from Sep 10 to Sep 13.',
     target_id: 2,
     target_kind: 'request',
     actor_name: 'Marina Costa',
@@ -247,10 +292,10 @@ export const notifications = [
     id: 3,
     type: 'intern_paused',
     title: 'Intern paused',
-    body: 'Ana Bezerra learning journey paused by mentor.',
-    target_id: 4,
+    body: 'Ana Carolina learning journey paused by mentor.',
+    target_id: 'ana',
     target_kind: 'intern',
-    actor_name: 'Ana Ribeiro',
+    actor_name: 'João Freitas',
     created_date: '2024-07-22T14:30:00.000Z',
     read: false
   }
@@ -259,39 +304,39 @@ export const notifications = [
 export const vacationRequests = [
   {
     id: 1,
-    intern_id: 3,
+    intern_id: 'caio',
     status: 'approved',
-    start_date: '2024-08-21T00:00:00.000Z',
-    end_date: '2024-08-25T00:00:00.000Z',
-    created_date: '2024-07-15T09:30:00.000Z',
-    decided_at: '2024-07-20T10:00:00.000Z',
-    manager_note: 'Enjoy a well deserved break!'
+    start_date: '2024-08-26T00:00:00.000Z',
+    end_date: '2024-08-30T00:00:00.000Z',
+    created_date: '2024-07-18T09:30:00.000Z',
+    decided_at: '2024-07-22T10:00:00.000Z',
+    manager_note: 'Aproveite a folga e volte com energia!'
   },
   {
     id: 2,
-    intern_id: 2,
+    intern_id: 'gabriela',
     status: 'pending',
     start_date: '2024-09-10T00:00:00.000Z',
-    end_date: '2024-09-12T00:00:00.000Z',
+    end_date: '2024-09-13T00:00:00.000Z',
     created_date: '2024-08-05T11:00:00.000Z',
     reason: 'Family trip to visit grandparents.'
   },
   {
     id: 3,
-    intern_id: 4,
+    intern_id: 'lucas',
     status: 'rejected',
-    start_date: '2024-08-15T00:00:00.000Z',
-    end_date: '2024-08-16T00:00:00.000Z',
-    created_date: '2024-07-28T13:00:00.000Z',
-    decided_at: '2024-07-30T09:00:00.000Z',
-    manager_note: 'Need you during the onboarding sprint.'
+    start_date: '2024-09-02T00:00:00.000Z',
+    end_date: '2024-09-06T00:00:00.000Z',
+    created_date: '2024-08-08T10:30:00.000Z',
+    decided_at: '2024-08-10T09:00:00.000Z',
+    manager_note: 'Vamos precisar de você no hackathon interno.'
   }
 ];
 
 export const chatMessages = [
   {
     id: 1,
-    intern_id: 1,
+    intern_id: 'caio',
     from: 'intern',
     text: 'Oi! Você poderia revisar o meu último pull request? 😊',
     created_date: '2024-08-14T13:12:00.000Z',
@@ -299,7 +344,7 @@ export const chatMessages = [
   },
   {
     id: 2,
-    intern_id: 1,
+    intern_id: 'caio',
     from: 'manager',
     text: 'Claro! Vou olhar ainda hoje e te aviso.',
     created_date: '2024-08-14T13:18:00.000Z',
@@ -307,11 +352,19 @@ export const chatMessages = [
   },
   {
     id: 3,
-    intern_id: 2,
+    intern_id: 'gabriela',
     from: 'intern',
     text: 'Terminei o estudo de caso. Podemos conversar amanhã?',
     created_date: '2024-08-13T09:45:00.000Z',
     read: true
+  },
+  {
+    id: 4,
+    intern_id: 'lucas',
+    from: 'intern',
+    text: 'Enviei o protótipo do assistente, feedbacks são bem-vindos!',
+    created_date: '2024-08-15T15:05:00.000Z',
+    read: false
   }
 ];
 

--- a/Ascenda Padrinho att/src/entities/store.js
+++ b/Ascenda Padrinho att/src/entities/store.js
@@ -81,8 +81,24 @@ const cleanUpdates = (updates = {}) => {
   return result;
 };
 
-export function createEntityStore(storageKey, initialData = []) {
+export function createEntityStore(storageKey, initialData = [], options = {}) {
+  const { version, migrate } = options;
+  const versionKey = `${storageKey}_version`;
+
   let data = readStorage(storageKey, clone(initialData));
+
+  if (version) {
+    const storedVersion = readStorage(versionKey, null);
+    if (storedVersion !== version) {
+      const nextData = typeof migrate === 'function'
+        ? migrate(clone(data), clone(initialData))
+        : clone(initialData);
+
+      data = nextData;
+      writeStorage(storageKey, data);
+      writeStorage(versionKey, version);
+    }
+  }
 
   const persist = () => writeStorage(storageKey, data);
 

--- a/Ascenda Padrinho att/src/i18n/LanguageProvider.jsx
+++ b/Ascenda Padrinho att/src/i18n/LanguageProvider.jsx
@@ -1,0 +1,97 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import en from './en';
+import pt from './pt';
+
+const STORAGE_KEY = 'language';
+export const translations = { en, pt };
+
+function interpolate(template, values) {
+  if (!template || !values) return template;
+  return template.replace(/\{\{(.*?)\}\}/g, (_, token) => {
+    const valueKey = token.trim();
+    return Object.prototype.hasOwnProperty.call(values, valueKey)
+      ? values[valueKey]
+      : `{{${valueKey}}}`;
+  });
+}
+
+function getNestedTranslation(language, key) {
+  const source = translations[language] || translations.en;
+  return key
+    .split('.')
+    .reduce((acc, part) => (acc && acc[part] !== undefined ? acc[part] : undefined), source);
+}
+
+const LanguageContext = createContext({
+  language: 'en',
+  setLanguage: () => {},
+  t: (key, fallback, values) => {
+    const message = fallback ?? key;
+    return typeof message === 'string' ? interpolate(message, values) : message;
+  },
+});
+
+export function LanguageProvider({ children }) {
+  const [language, setLanguage] = useState(() => {
+    if (typeof window === 'undefined') {
+      return 'en';
+    }
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored && translations[stored] ? stored : 'en';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && translations[stored]) {
+      setLanguage(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('lang', language);
+    }
+  }, [language]);
+
+  const changeLanguage = useCallback((next) => {
+    setLanguage((prev) => {
+      const nextLanguage = translations[next] ? next : prev;
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, nextLanguage);
+      }
+      return nextLanguage;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage: changeLanguage,
+      t: (key, fallback, values) => {
+        const message = getNestedTranslation(language, key) ?? fallback ?? key;
+        if (typeof message === 'string') {
+          return interpolate(message, values);
+        }
+        return message;
+      },
+    }),
+    [language, changeLanguage],
+  );
+
+  return (
+    <LanguageContext.Provider value={value}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useTranslation() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useTranslation must be used within LanguageProvider');
+  }
+  return context;
+}

--- a/Ascenda Padrinho att/src/i18n/en.js
+++ b/Ascenda Padrinho att/src/i18n/en.js
@@ -1,0 +1,184 @@
+const en = {
+  common: {
+    cancel: 'Cancel',
+    save: 'Save',
+  },
+  language: {
+    english: 'English',
+    portuguese: 'Português',
+  },
+  layout: {
+    appName: 'Ascenda',
+    subtitle: 'Manager Portal',
+    navigation: 'Navigation',
+    logout: 'Logout',
+    navItems: {
+      dashboard: 'Dashboard',
+      interns: 'Team Overview',
+      content: 'Content Management',
+      vacation: 'Vacation Requests',
+      reports: 'Reports',
+    },
+    userFallback: 'Manager',
+  },
+  dashboard: {
+    title: 'Welcome back, {{name}}!',
+    subtitle: "Here's what's happening with your team today",
+    cards: {
+      interns: {
+        title: 'Total Interns',
+        trend: '+2 this month',
+      },
+      courses: {
+        title: 'Courses Available',
+      },
+      reviews: {
+        title: 'Pending Reviews',
+      },
+      points: {
+        title: 'Team Points',
+        trend: '+15%'
+      },
+    },
+    status: {
+      heading: 'Intern Status & Well-being',
+      count: '{{count}} interns',
+      progressLabel: 'Internship Progress',
+      daysLeft: '{{count}} days left',
+      systemStatus: 'System Status',
+      active: 'Active',
+      paused: 'Paused',
+    },
+    notifications: {
+      pausedTitle: 'Intern Paused',
+      resumedTitle: 'Intern Resumed',
+      pausedBody: 'Learning system paused for {{name}}',
+      resumedBody: 'Learning system resumed for {{name}}',
+    },
+  },
+  interns: {
+    title: 'Team Overview',
+    subtitle: "Manage and track your team's progress",
+    searchPlaceholder: 'Search interns...',
+    levelPlaceholder: 'Level',
+    statusPlaceholder: 'Status',
+    filters: {
+      allLevels: 'All Levels',
+      novice: 'Novice',
+      apprentice: 'Apprentice',
+      journeyman: 'Journeyman',
+      expert: 'Expert',
+      master: 'Master',
+      allStatus: 'All Status',
+      active: 'Active',
+      paused: 'Paused',
+      completed: 'Completed',
+    },
+    empty: 'No interns found matching your filters',
+    card: {
+      points: 'Points',
+      avgScore: '{{value}}% avg',
+      daysLeft: '{{count}}d left',
+      chat: 'Chat',
+      trackFallback: 'Learning Track',
+      progressTitle: 'Well-being: {{status}}',
+    },
+  },
+  content: {
+    title: 'Content Management',
+    subtitle: 'Create and manage training materials for your team',
+    libraryTitle: 'Course Library',
+    courseCount: '{{count}} courses',
+    empty: 'No courses yet. Create your first one!',
+  },
+  vacations: {
+    title: 'Vacation Requests',
+    subtitle: 'Review and manage intern vacation requests',
+    panel: {
+      heading: 'Vacation Requests',
+      tabs: {
+        list: 'Requests List',
+        calendar: 'Calendar View',
+      },
+      filterPlaceholder: 'Filter',
+      filters: {
+        all: 'All Requests',
+        pending: 'Pending',
+        approved: 'Approved',
+        rejected: 'Rejected',
+      },
+      count: {
+        one: '1 request',
+        other: '{{count}} requests',
+      },
+      aria: {
+        listItem: 'Vacation request from {{name}}',
+        updateEmoji: 'Update profile emoji for {{name}}',
+        approve: 'Approve vacation request for {{name}}',
+        reject: 'Reject vacation request for {{name}}',
+      },
+      fields: {
+        from: 'From',
+        to: 'To',
+        reason: 'Reason',
+        managerNote: 'Manager note:',
+        requestedOn: 'Requested {{date}}',
+        trackFallback: 'Learning track',
+      },
+      actions: {
+        approve: 'Approve',
+        reject: 'Reject',
+        saveEmoji: 'Save Emoji',
+        rejectRequest: 'Reject Request',
+      },
+      empty: 'No vacation requests found',
+      emojiDialog: {
+        title: 'Update Profile Emoji',
+        description: 'Choose an emoji or paste an image URL for {{name}}.',
+        placeholder: 'Try 😀 or paste an image URL',
+        helper: 'Emojis render beautifully across the app and you can swap them anytime. Image URLs are also supported.',
+        previewLabel: 'Preview',
+      },
+      rejectDialog: {
+        title: 'Reject Vacation Request',
+        description: 'Are you sure you want to reject this vacation request? You can optionally add a note.',
+        noteLabel: 'Manager Note (Optional)',
+        notePlaceholder: 'Explain the reason for rejection...',
+      },
+      notifications: {
+        approvedTitle: 'Vacation Request Approved',
+        approvedBody: 'Your vacation request from {{start}} to {{end}} has been approved.',
+        rejectedTitle: 'Vacation Request Rejected',
+        rejectedBody: 'Your vacation request from {{start}} to {{end}} has been rejected.',
+        noteSuffix: ' Note: {{note}}',
+      },
+    },
+  },
+  reports: {
+    title: 'Reports & Analytics',
+    subtitle: "Insights into your team's performance and progress",
+    export: 'Export Report',
+    charts: {
+      teamPerformance: 'Team Performance (Top 10)',
+      taskDistribution: 'Task Distribution',
+      statuses: {
+        completed: 'Completed',
+        in_progress: 'In Progress',
+        pending: 'Pending',
+        overdue: 'Overdue',
+        empty: 'No task data available',
+      },
+      performanceEmpty: 'No performance data available',
+      legendPoints: 'Points',
+    },
+    metrics: {
+      title: 'Key Metrics Summary',
+      totalInterns: 'Total Interns',
+      activeTasks: 'Active Tasks',
+      availableCourses: 'Available Courses',
+      avgPoints: 'Avg. Points',
+    },
+  },
+};
+
+export default en;

--- a/Ascenda Padrinho att/src/i18n/index.js
+++ b/Ascenda Padrinho att/src/i18n/index.js
@@ -1,0 +1,1 @@
+export * from './LanguageProvider.jsx';

--- a/Ascenda Padrinho att/src/i18n/pt.js
+++ b/Ascenda Padrinho att/src/i18n/pt.js
@@ -1,0 +1,184 @@
+const pt = {
+  common: {
+    cancel: 'Cancelar',
+    save: 'Salvar',
+  },
+  language: {
+    english: 'English',
+    portuguese: 'Português',
+  },
+  layout: {
+    appName: 'Ascenda',
+    subtitle: 'Portal do Gestor',
+    navigation: 'Navegação',
+    logout: 'Sair',
+    navItems: {
+      dashboard: 'Painel',
+      interns: 'Equipe',
+      content: 'Conteúdo',
+      vacation: 'Férias',
+      reports: 'Relatórios',
+    },
+    userFallback: 'Gestor',
+  },
+  dashboard: {
+    title: 'Bem-vindo de volta, {{name}}!',
+    subtitle: 'Veja o que está acontecendo com a sua equipe hoje',
+    cards: {
+      interns: {
+        title: 'Estagiários',
+        trend: '+2 este mês',
+      },
+      courses: {
+        title: 'Cursos Disponíveis',
+      },
+      reviews: {
+        title: 'Revisões Pendentes',
+      },
+      points: {
+        title: 'Pontos da Equipe',
+        trend: '+15%'
+      },
+    },
+    status: {
+      heading: 'Bem-estar dos Estagiários',
+      count: '{{count}} estagiários',
+      progressLabel: 'Progresso do Estágio',
+      daysLeft: '{{count}} dias restantes',
+      systemStatus: 'Status do Sistema',
+      active: 'Ativo',
+      paused: 'Pausado',
+    },
+    notifications: {
+      pausedTitle: 'Estagiário Pausado',
+      resumedTitle: 'Estagiário Retomado',
+      pausedBody: 'Sistema de aprendizagem pausado para {{name}}',
+      resumedBody: 'Sistema de aprendizagem retomado para {{name}}',
+    },
+  },
+  interns: {
+    title: 'Equipe',
+    subtitle: 'Gerencie e acompanhe o progresso da equipe',
+    searchPlaceholder: 'Buscar estagiários...',
+    levelPlaceholder: 'Nível',
+    statusPlaceholder: 'Status',
+    filters: {
+      allLevels: 'Todos os níveis',
+      novice: 'Iniciante',
+      apprentice: 'Aprendiz',
+      journeyman: 'Intermediário',
+      expert: 'Especialista',
+      master: 'Mestre',
+      allStatus: 'Todos os status',
+      active: 'Ativo',
+      paused: 'Pausado',
+      completed: 'Concluído',
+    },
+    empty: 'Nenhum estagiário encontrado com esses filtros',
+    card: {
+      points: 'Pontos',
+      avgScore: 'Média de {{value}}%',
+      daysLeft: '{{count}}d restantes',
+      chat: 'Conversar',
+      trackFallback: 'Trilha de Aprendizagem',
+      progressTitle: 'Bem-estar: {{status}}',
+    },
+  },
+  content: {
+    title: 'Gestão de Conteúdo',
+    subtitle: 'Crie e gerencie materiais de treinamento para a equipe',
+    libraryTitle: 'Biblioteca de Cursos',
+    courseCount: '{{count}} cursos',
+    empty: 'Nenhum curso ainda. Crie o primeiro!',
+  },
+  vacations: {
+    title: 'Solicitações de Férias',
+    subtitle: 'Revise e gerencie os pedidos de férias dos estagiários',
+    panel: {
+      heading: 'Solicitações de Férias',
+      tabs: {
+        list: 'Lista de Pedidos',
+        calendar: 'Visão em Calendário',
+      },
+      filterPlaceholder: 'Filtrar',
+      filters: {
+        all: 'Todos os Pedidos',
+        pending: 'Pendentes',
+        approved: 'Aprovados',
+        rejected: 'Rejeitados',
+      },
+      count: {
+        one: '1 pedido',
+        other: '{{count}} pedidos',
+      },
+      aria: {
+        listItem: 'Pedido de férias de {{name}}',
+        updateEmoji: 'Atualizar emoji de perfil de {{name}}',
+        approve: 'Aprovar pedido de férias de {{name}}',
+        reject: 'Rejeitar pedido de férias de {{name}}',
+      },
+      fields: {
+        from: 'De',
+        to: 'Até',
+        reason: 'Motivo',
+        managerNote: 'Nota do gestor:',
+        requestedOn: 'Solicitado em {{date}}',
+        trackFallback: 'Trilha de aprendizagem',
+      },
+      actions: {
+        approve: 'Aprovar',
+        reject: 'Rejeitar',
+        saveEmoji: 'Salvar emoji',
+        rejectRequest: 'Rejeitar pedido',
+      },
+      empty: 'Nenhum pedido de férias encontrado',
+      emojiDialog: {
+        title: 'Atualizar emoji do perfil',
+        description: 'Escolha um emoji ou cole uma URL de imagem para {{name}}.',
+        placeholder: 'Experimente 😀 ou cole uma URL de imagem',
+        helper: 'Os emojis aparecem lindamente no aplicativo e você pode trocá-los quando quiser. URLs de imagem também são suportadas.',
+        previewLabel: 'Pré-visualização',
+      },
+      rejectDialog: {
+        title: 'Rejeitar solicitação de férias',
+        description: 'Tem certeza de que deseja rejeitar esta solicitação de férias? Você pode adicionar uma nota opcional.',
+        noteLabel: 'Nota do gestor (opcional)',
+        notePlaceholder: 'Explique o motivo da rejeição...',
+      },
+      notifications: {
+        approvedTitle: 'Solicitação de férias aprovada',
+        approvedBody: 'Seu pedido de férias de {{start}} até {{end}} foi aprovado.',
+        rejectedTitle: 'Solicitação de férias rejeitada',
+        rejectedBody: 'Seu pedido de férias de {{start}} até {{end}} foi rejeitado.',
+        noteSuffix: ' Observação: {{note}}',
+      },
+    },
+  },
+  reports: {
+    title: 'Relatórios e Análises',
+    subtitle: 'Insights sobre o desempenho e o progresso da equipe',
+    export: 'Exportar relatório',
+    charts: {
+      teamPerformance: 'Desempenho da equipe (Top 10)',
+      taskDistribution: 'Distribuição de tarefas',
+      statuses: {
+        completed: 'Concluídas',
+        in_progress: 'Em andamento',
+        pending: 'Pendentes',
+        overdue: 'Atrasadas',
+        empty: 'Nenhum dado de tarefas disponível',
+      },
+      performanceEmpty: 'Nenhum dado de desempenho disponível',
+      legendPoints: 'Pontos',
+    },
+    metrics: {
+      title: 'Resumo de métricas',
+      totalInterns: 'Total de estagiários',
+      activeTasks: 'Tarefas ativas',
+      availableCourses: 'Cursos disponíveis',
+      avgPoints: 'Pontuação média',
+    },
+  },
+};
+
+export default pt;

--- a/Ascenda Padrinho att/src/main.jsx
+++ b/Ascenda Padrinho att/src/main.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
+import { LanguageProvider } from './i18n';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
   </React.StrictMode>
 );
 

--- a/Ascenda Padrinho att/src/pages/ContentManagement.jsx
+++ b/Ascenda Padrinho att/src/pages/ContentManagement.jsx
@@ -6,6 +6,7 @@ import CourseCard from "../components/content/CourseCard";
 import CourseEditModal from "../components/content/CourseEditModal";
 import PreviewDrawer from "../components/media/PreviewDrawer";
 import AssignCourseModal from "../components/courses/AssignCourseModal";
+import { useTranslation } from "../i18n";
 
 export default function ContentManagement() {
   const [courses, setCourses] = useState([]);
@@ -15,6 +16,7 @@ export default function ContentManagement() {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [assigningCourse, setAssigningCourse] = useState(null);
   const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
+  const { t } = useTranslation();
 
   const loadCourses = useCallback(async () => {
     const data = await Course.list('-created_date');
@@ -67,9 +69,11 @@ export default function ContentManagement() {
           animate={{ opacity: 1, y: 0 }}
         >
           <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-            Content Management
+            {t('content.title', 'Content Management')}
           </h1>
-          <p className="text-muted">Create and manage training materials for your team</p>
+          <p className="text-muted">
+            {t('content.subtitle', 'Create and manage training materials for your team')}
+          </p>
         </motion.div>
 
         <div className="grid lg:grid-cols-3 gap-8">
@@ -82,8 +86,12 @@ export default function ContentManagement() {
 
           <div className="lg:col-span-2 space-y-6">
             <div className="flex items-center justify-between">
-              <h2 className="text-2xl font-bold text-primary">Course Library</h2>
-              <span className="text-sm text-muted">{courses.length} courses</span>
+              <h2 className="text-2xl font-bold text-primary">
+                {t('content.libraryTitle', 'Course Library')}
+              </h2>
+              <span className="text-sm text-muted">
+                {t('content.courseCount', '{{count}} courses', { count: courses.length })}
+              </span>
             </div>
 
             <div className="grid gap-6">
@@ -101,7 +109,9 @@ export default function ContentManagement() {
 
             {courses.length === 0 && (
               <div className="text-center py-12 bg-surface2 border border-border rounded-xl">
-                <p className="text-muted">No courses yet. Create your first one!</p>
+                <p className="text-muted">
+                  {t('content.empty', 'No courses yet. Create your first one!')}
+                </p>
               </div>
             )}
           </div>

--- a/Ascenda Padrinho att/src/pages/Dashboard.jsx
+++ b/Ascenda Padrinho att/src/pages/Dashboard.jsx
@@ -9,12 +9,14 @@ import SummaryCard from "../components/dashboard/SummaryCard";
 import InternStatusCard from "../components/dashboard/InternStatusCard";
 import { motion } from "framer-motion";
 import { eventBus, EventTypes } from "../components/utils/eventBus";
+import { useTranslation } from "../i18n";
 
 export default function Dashboard() {
   const [interns, setInterns] = useState([]);
   const [courses, setCourses] = useState([]);
   const [tasks, setTasks] = useState([]);
   const [user, setUser] = useState(null);
+  const { t } = useTranslation();
 
   useEffect(() => {
     loadData();
@@ -55,11 +57,21 @@ export default function Dashboard() {
 
     await Notification.create({
       type: newStatus === 'paused' ? 'intern_paused' : 'intern_resumed',
-      title: `Intern ${newStatus === 'paused' ? 'Paused' : 'Resumed'}`,
-      body: `Learning system ${newStatus === 'paused' ? 'paused' : 'resumed'} for ${intern.full_name}`,
+      title:
+        newStatus === 'paused'
+          ? t('dashboard.notifications.pausedTitle', 'Intern Paused')
+          : t('dashboard.notifications.resumedTitle', 'Intern Resumed'),
+      body:
+        newStatus === 'paused'
+          ? t('dashboard.notifications.pausedBody', 'Learning system paused for {{name}}', {
+              name: intern.full_name,
+            })
+          : t('dashboard.notifications.resumedBody', 'Learning system resumed for {{name}}', {
+              name: intern.full_name,
+            }),
       target_id: intern.id,
       target_kind: 'intern',
-      actor_name: user?.full_name || 'Manager'
+      actor_name: user?.full_name || t('layout.userFallback', 'Manager')
     });
 
     eventBus.emit(newStatus === 'paused' ? EventTypes.INTERN_PAUSED : EventTypes.INTERN_RESUMED, {
@@ -80,48 +92,56 @@ export default function Dashboard() {
           animate={{ opacity: 1, y: 0 }}
         >
           <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-            Welcome back, {user?.full_name || 'Manager'}!
+            {t('dashboard.title', 'Welcome back, {{name}}!', {
+              name: user?.full_name || 'Manager',
+            })}
           </h1>
-          <p className="text-muted">Here's what's happening with your team today</p>
+          <p className="text-muted">
+            {t("dashboard.subtitle", "Here's what's happening with your team today")}
+          </p>
         </motion.div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <SummaryCard
-            title="Total Interns"
+            title={t('dashboard.cards.interns.title', 'Total Interns')}
             value={interns.length}
             icon={Users}
             gradient="bg-gradient-to-br from-brand to-blue-600"
-            trend="+2 this month"
+            trend={t('dashboard.cards.interns.trend', '+2 this month')}
             delay={0.1}
           />
           <SummaryCard
-            title="Courses Available"
+            title={t('dashboard.cards.courses.title', 'Courses Available')}
             value={courses.length}
             icon={BookOpen}
             gradient="bg-gradient-to-br from-brand2 to-pink-600"
             delay={0.2}
           />
           <SummaryCard
-            title="Pending Reviews"
+            title={t('dashboard.cards.reviews.title', 'Pending Reviews')}
             value={pendingTasks}
             icon={ClipboardCheck}
             gradient="bg-gradient-to-br from-brand2 to-yellow-600"
             delay={0.3}
           />
           <SummaryCard
-            title="Team Points"
+            title={t('dashboard.cards.points.title', 'Team Points')}
             value={totalPoints}
             icon={Trophy}
             gradient="bg-gradient-to-br from-yellow-600 to-pink-600"
-            trend="+15%"
+            trend={t('dashboard.cards.points.trend', '+15%')}
             delay={0.4}
           />
         </div>
 
         <div>
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-2xl font-bold text-primary">Intern Status & Well-being</h2>
-            <span className="text-sm text-muted">{interns.length} interns</span>
+            <h2 className="text-2xl font-bold text-primary">
+              {t('dashboard.status.heading', 'Intern Status & Well-being')}
+            </h2>
+            <span className="text-sm text-muted">
+              {t('dashboard.status.count', '{{count}} interns', { count: interns.length })}
+            </span>
           </div>
           
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/Ascenda Padrinho att/src/pages/Interns.jsx
+++ b/Ascenda Padrinho att/src/pages/Interns.jsx
@@ -13,6 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useTranslation } from "../i18n";
 
 export default function Interns() {
   const [interns, setInterns] = useState([]);
@@ -23,6 +24,7 @@ export default function Interns() {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterLevel, setFilterLevel] = useState("all");
   const [filterStatus, setFilterStatus] = useState("all");
+  const { t } = useTranslation();
 
   useEffect(() => {
     loadInterns();
@@ -71,9 +73,11 @@ export default function Interns() {
         >
           <div>
             <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-              Team Overview
+              {t('interns.title', 'Team Overview')}
             </h1>
-            <p className="text-muted">Manage and track your team's progress</p>
+            <p className="text-muted">
+              {t("interns.subtitle", "Manage and track your team's progress")}
+            </p>
           </div>
         </motion.div>
 
@@ -81,7 +85,7 @@ export default function Interns() {
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-muted" />
             <Input
-              placeholder="Search interns..."
+              placeholder={t('interns.searchPlaceholder', 'Search interns...')}
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               className="pl-10 bg-surface border-border text-primary placeholder:text-muted focus:border-brand"
@@ -91,28 +95,28 @@ export default function Interns() {
           <Select value={filterLevel} onValueChange={setFilterLevel}>
             <SelectTrigger className="w-full md:w-40 bg-surface border-border text-primary">
               <Filter className="w-4 h-4 mr-2" />
-              <SelectValue placeholder="Level" />
+              <SelectValue placeholder={t('interns.levelPlaceholder', 'Level')} />
             </SelectTrigger>
             <SelectContent className="bg-surface border-border">
-              <SelectItem value="all">All Levels</SelectItem>
-              <SelectItem value="Novice">Novice</SelectItem>
-              <SelectItem value="Apprentice">Apprentice</SelectItem>
-              <SelectItem value="Journeyman">Journeyman</SelectItem>
-              <SelectItem value="Expert">Expert</SelectItem>
-              <SelectItem value="Master">Master</SelectItem>
+              <SelectItem value="all">{t('interns.filters.allLevels', 'All Levels')}</SelectItem>
+              <SelectItem value="Novice">{t('interns.filters.novice', 'Novice')}</SelectItem>
+              <SelectItem value="Apprentice">{t('interns.filters.apprentice', 'Apprentice')}</SelectItem>
+              <SelectItem value="Journeyman">{t('interns.filters.journeyman', 'Journeyman')}</SelectItem>
+              <SelectItem value="Expert">{t('interns.filters.expert', 'Expert')}</SelectItem>
+              <SelectItem value="Master">{t('interns.filters.master', 'Master')}</SelectItem>
             </SelectContent>
           </Select>
 
           <Select value={filterStatus} onValueChange={setFilterStatus}>
             <SelectTrigger className="w-full md:w-40 bg-surface border-border text-primary">
               <Filter className="w-4 h-4 mr-2" />
-              <SelectValue placeholder="Status" />
+              <SelectValue placeholder={t('interns.statusPlaceholder', 'Status')} />
             </SelectTrigger>
             <SelectContent className="bg-surface border-border">
-              <SelectItem value="all">All Status</SelectItem>
-              <SelectItem value="active">Active</SelectItem>
-              <SelectItem value="paused">Paused</SelectItem>
-              <SelectItem value="completed">Completed</SelectItem>
+              <SelectItem value="all">{t('interns.filters.allStatus', 'All Status')}</SelectItem>
+              <SelectItem value="active">{t('interns.filters.active', 'Active')}</SelectItem>
+              <SelectItem value="paused">{t('interns.filters.paused', 'Paused')}</SelectItem>
+              <SelectItem value="completed">{t('interns.filters.completed', 'Completed')}</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -131,7 +135,9 @@ export default function Interns() {
 
         {filteredInterns.length === 0 && (
           <div className="text-center py-12">
-            <p className="text-muted">No interns found matching your filters</p>
+            <p className="text-muted">
+              {t('interns.empty', 'No interns found matching your filters')}
+            </p>
           </div>
         )}
 

--- a/Ascenda Padrinho att/src/pages/Reports.jsx
+++ b/Ascenda Padrinho att/src/pages/Reports.jsx
@@ -8,11 +8,13 @@ import { Download } from "lucide-react";
 import { motion } from "framer-motion";
 import TeamPerformanceChart from "../components/reports/TeamPerformanceChart";
 import TaskCompletionChart from "../components/reports/TaskCompletionChart";
+import { useTranslation } from "../i18n";
 
 export default function Reports() {
   const [interns, setInterns] = useState([]);
   const [tasks, setTasks] = useState([]);
   const [courses, setCourses] = useState([]);
+  const { t } = useTranslation();
 
   useEffect(() => {
     loadData();
@@ -76,16 +78,18 @@ export default function Reports() {
         >
           <div>
             <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-              Reports & Analytics
+              {t('reports.title', 'Reports & Analytics')}
             </h1>
-            <p className="text-muted">Insights into your team's performance and progress</p>
+            <p className="text-muted">
+              {t('reports.subtitle', "Insights into your team's performance and progress")}
+            </p>
           </div>
           <Button
             onClick={downloadReport}
             className="bg-brand hover:bg-brand/90 text-white"
           >
             <Download className="w-4 h-4 mr-2" />
-            Export Report
+            {t('reports.export', 'Export Report')}
           </Button>
         </motion.div>
 
@@ -93,7 +97,7 @@ export default function Reports() {
           <Card className="border-border bg-surface shadow-e1">
             <CardHeader>
               <CardTitle className="text-primary">
-                Team Performance (Top 10)
+                {t('reports.charts.teamPerformance', 'Team Performance (Top 10)')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -106,7 +110,7 @@ export default function Reports() {
           <Card className="border-border bg-surface shadow-e1">
             <CardHeader>
               <CardTitle className="text-primary">
-                Task Distribution
+                {t('reports.charts.taskDistribution', 'Task Distribution')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -120,25 +124,25 @@ export default function Reports() {
         <Card className="border-border bg-surface shadow-e1">
           <CardHeader>
             <CardTitle className="text-primary">
-              Key Metrics Summary
+              {t('reports.metrics.title', 'Key Metrics Summary')}
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
               <div className="text-center p-4 bg-surface2 rounded-xl border border-border">
-                <p className="text-sm text-muted mb-2">Total Interns</p>
+                <p className="text-sm text-muted mb-2">{t('reports.metrics.totalInterns', 'Total Interns')}</p>
                 <p className="text-3xl font-bold text-primary">{interns.length}</p>
               </div>
               <div className="text-center p-4 bg-surface2 rounded-xl border border-border">
-                <p className="text-sm text-muted mb-2">Active Tasks</p>
+                <p className="text-sm text-muted mb-2">{t('reports.metrics.activeTasks', 'Active Tasks')}</p>
                 <p className="text-3xl font-bold text-primary">{tasks.length}</p>
               </div>
               <div className="text-center p-4 bg-surface2 rounded-xl border border-border">
-                <p className="text-sm text-muted mb-2">Available Courses</p>
+                <p className="text-sm text-muted mb-2">{t('reports.metrics.availableCourses', 'Available Courses')}</p>
                 <p className="text-3xl font-bold text-primary">{courses.length}</p>
               </div>
               <div className="text-center p-4 bg-surface2 rounded-xl border border-border">
-                <p className="text-sm text-muted mb-2">Avg. Points</p>
+                <p className="text-sm text-muted mb-2">{t('reports.metrics.avgPoints', 'Avg. Points')}</p>
                 <p className="text-3xl font-bold text-primary">
                   {interns.length > 0 ? Math.round(interns.reduce((sum, i) => sum + i.points, 0) / interns.length) : 0}
                 </p>

--- a/Ascenda Padrinho att/src/pages/VacationRequests.jsx
+++ b/Ascenda Padrinho att/src/pages/VacationRequests.jsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { motion } from "framer-motion";
 import VacationRequestsPanel from "../components/vacation/VacationRequestsPanel";
+import { useTranslation } from "../i18n";
 
 export default function VacationRequests() {
+  const { t } = useTranslation();
+
   return (
     <div className="min-h-screen p-6 md:p-8">
       <div className="max-w-5xl mx-auto space-y-8">
@@ -11,9 +14,11 @@ export default function VacationRequests() {
           animate={{ opacity: 1, y: 0 }}
         >
           <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-            Vacation Requests
+            {t('vacations.title', 'Vacation Requests')}
           </h1>
-          <p className="text-muted">Review and manage intern vacation requests</p>
+          <p className="text-muted">
+            {t('vacations.subtitle', 'Review and manage intern vacation requests')}
+          </p>
         </motion.div>
 
         <VacationRequestsPanel />


### PR DESCRIPTION
## Summary
- move the i18n provider implementation into a JSX module so Vite parses the context without syntax errors
- re-export the provider from the existing index entry point while guarding browser-only APIs such as localStorage and document.lang

## Testing
- not run (npm install fails: 403 Forbidden fetching @vitejs/plugin-react)


------
https://chatgpt.com/codex/tasks/task_e_68df274f6108832daba56458caaea876