### PR TITLE
Improve course filter UI and translation coverage

### DIFF
--- a/Ascenda Padrinho att/src/components/content/CourseCard.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseCard.jsx
@@ -115,8 +115,11 @@ export default function CourseCard({ course, index, onEdit, onPreview, onAssign 
                   <Users className="w-3 h-3 mr-1" />
                   {t(
                     "courseCard.active",
-                    '{{count}} active learner(s)',
-                    { count: assignmentCount },
+                    '{{count}} active learner{{suffix}}',
+                    {
+                      count: assignmentCount,
+                      suffix: assignmentCount === 1 ? '' : 's',
+                    },
                   )}
                 </Badge>
               )}

--- a/Ascenda Padrinho att/src/components/i18n/LanguageToggle.jsx
+++ b/Ascenda Padrinho att/src/components/i18n/LanguageToggle.jsx
@@ -26,7 +26,17 @@ export default function LanguageToggle() {
             aria-label={option.label}
             title={option.label}
           >
-            <span aria-hidden="true">{option.emoji}</span>
+            <span
+              aria-hidden="true"
+              role="img"
+              className="leading-none"
+              style={{
+                fontFamily:
+                  '"Twemoji Country Flags", "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", sans-serif',
+              }}
+            >
+              {option.emoji}
+            </span>
           </button>
         );
       })}

--- a/Ascenda Padrinho att/src/i18n/translations/en.js
+++ b/Ascenda Padrinho att/src/i18n/translations/en.js
@@ -248,10 +248,17 @@ const en = {
     title: "Content Management",
     subtitle: "Create and manage training materials for your team",
     libraryTitle: "Course Library",
-    courseCount: "{{count}} courses",
+    courseCount: "{{count}} course{{suffix}}",
     noCourses: "No courses yet. Create your first one!",
     empty: "No courses yet. Create your first one!",
-    addCourse: "Add New Course"
+    addCourse: "Add New Course",
+    filters: {
+      trainingType: "Training type",
+      trainingTypes: {
+        all: "All training types",
+      },
+    },
+    filteredCount: "{{count}} course{{suffix}} match this filter"
   },
   courseForm: {
     titleLabel: "Course Title *",

--- a/Ascenda Padrinho att/src/i18n/translations/pt.js
+++ b/Ascenda Padrinho att/src/i18n/translations/pt.js
@@ -248,10 +248,17 @@ const pt = {
     title: "Gestão de conteúdo",
     subtitle: "Crie e gerencie materiais de treinamento para sua equipe",
     libraryTitle: "Biblioteca de cursos",
-    courseCount: "{{count}} cursos",
+    courseCount: "{{count}} curso{{suffix}}",
     noCourses: "Ainda não há cursos. Crie o primeiro!",
     empty: "Ainda não há cursos. Crie o primeiro!",
-    addCourse: "Adicionar novo curso"
+    addCourse: "Adicionar novo curso",
+    filters: {
+      trainingType: "Tipo de treinamento",
+      trainingTypes: {
+        all: "Todos os tipos",
+      },
+    },
+    filteredCount: "{{count}} curso{{suffix}} corresponde a este filtro"
   },
   courseForm: {
     titleLabel: "Título do curso *",

--- a/Ascenda Padrinho att/src/pages/ContentManagement.jsx
+++ b/Ascenda Padrinho att/src/pages/ContentManagement.jsx
@@ -7,13 +7,6 @@ import CourseEditModal from "../components/content/CourseEditModal";
 import PreviewDrawer from "../components/media/PreviewDrawer";
 import AssignCourseModal from "../components/courses/AssignCourseModal";
 import { useTranslation } from "../i18n";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useTrainingTypeOptions } from "@/utils/labels";
 
 export default function ContentManagement() {
@@ -109,22 +102,46 @@ export default function ContentManagement() {
               <h2 className="text-2xl font-bold text-primary">
                 {t('content.libraryTitle', 'Course Library')}
               </h2>
-              <div className="flex items-center gap-3">
-                <span className="text-sm text-muted">
-                  {t('content.courseCount', '{{count}} courses', { count: courses.length })}
-                </span>
-                <Select value={trainingFilter} onValueChange={setTrainingFilter}>
-                  <SelectTrigger className="w-48 bg-surface2 border-border text-primary">
-                    <SelectValue placeholder={t('content.filters.trainingType', 'Training type')} />
-                  </SelectTrigger>
-                  <SelectContent className="bg-surface border-border">
-                    {trainingOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+              <div className="w-full lg:w-auto space-y-2">
+                <p className="text-sm text-muted">
+                  {t(
+                    'content.courseCount',
+                    '{{count}} course{{suffix}}',
+                    {
+                      count: courses.length,
+                      suffix: courses.length === 1 ? '' : 's',
+                    },
+                  )}
+                </p>
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted">
+                    {t('content.filters.trainingType', 'Training type')}
+                  </p>
+                  <div
+                    className="mt-2 flex flex-wrap gap-2 rounded-2xl border border-border bg-surface2/80 p-2"
+                    role="group"
+                    aria-label={t('content.filters.trainingType', 'Training type')}
+                  >
+                    {trainingOptions.map((option) => {
+                      const isActive = trainingFilter === option.value;
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          onClick={() => setTrainingFilter(option.value)}
+                          className={`rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
+                            isActive
+                              ? 'border-brand bg-brand text-white shadow-e1'
+                              : 'border-border/60 bg-surface text-secondary hover:border-brand/60 hover:text-primary'
+                          }`}
+                          aria-pressed={isActive}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
               </div>
             </div>
 
@@ -132,8 +149,11 @@ export default function ContentManagement() {
               <p className="text-xs text-muted">
                 {t(
                   'content.filteredCount',
-                  '{{count}} course(s) match this filter',
-                  { count: filteredCourses.length },
+                  '{{count}} course{{suffix}} match this filter',
+                  {
+                    count: filteredCourses.length,
+                    suffix: filteredCourses.length === 1 ? '' : 's',
+                  },
                 )}
               </p>
             )}


### PR DESCRIPTION
## Summary
- restyle the course library training-type filter into pill buttons and adjust pluralized counts
- add missing English and Portuguese strings for the new filters and filtered count messages
- fix active assignment suffix handling and ensure the language toggle flags render reliably

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e022349518832d87be938f725f740a