### PR TITLE
Refine content management layout and filters

### DIFF
--- a/Ascenda Padrinho att/src/components/content/CourseCard.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseCard.jsx
@@ -2,7 +2,18 @@ import React, { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { BookOpen, Clock, Users, TrendingUp, Pencil, Eye, Youtube, FileText, UserPlus } from "lucide-react";
+import {
+  BookOpen,
+  Clock,
+  Users,
+  TrendingUp,
+  Pencil,
+  Eye,
+  Youtube,
+  FileText,
+  UserPlus,
+  Layers,
+} from "lucide-react";
 import { motion } from "framer-motion";
 import { CourseAssignment } from "@/entities/CourseAssignment";
 import { useTranslation } from "@/i18n";
@@ -65,22 +76,38 @@ export default function CourseCard({ course, index, onEdit, onPreview, onAssign 
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
+      initial={{ opacity: 0, y: 24 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.05 }}
+      className="group"
     >
-      <Card className="border-border bg-surface hover:shadow-e2 transition-all duration-350 group shadow-e1">
-        <CardContent className="p-6">
-          <div className="space-y-4">
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex-1 min-w-0">
-                <h3 className="font-semibold text-primary text-lg mb-2 group-hover:text-brand transition-colors">
+      <Card className="relative overflow-hidden border border-border/60 bg-surface/80 shadow-e1 transition-all duration-300 hover:-translate-y-1 hover:shadow-e3">
+        <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-brand via-brand2/70 to-brand" />
+        <CardContent className="relative p-6">
+          <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
+                  <span className="inline-flex items-center gap-1 rounded-full bg-surface2/70 px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-secondary">
+                    <Layers className="h-3 w-3" />
+                    {t('courseCard.label', 'Featured course')}
+                  </span>
+                  {course.training_type && trainingTypeLabel && (
+                    <span className="inline-flex items-center gap-1 text-[11px] text-muted">
+                      <BookOpen className="h-3 w-3" />
+                      {trainingTypeLabel}
+                    </span>
+                  )}
+                </div>
+                <h3 className="text-xl font-semibold text-primary transition-colors group-hover:text-brand">
                   {course.title}
                 </h3>
-                <p className="text-sm text-muted line-clamp-2">{course.description}</p>
+                <p className="text-sm leading-relaxed text-muted line-clamp-2">
+                  {course.description}
+                </p>
               </div>
-              <div className="p-3 rounded-xl bg-surface2 border border-border shrink-0">
-                <BookOpen className="w-5 h-5 text-brand" />
+              <div className="shrink-0 rounded-2xl border border-border/60 bg-surface2 p-3 text-brand">
+                <BookOpen className="h-5 w-5" />
               </div>
             </div>
 
@@ -99,69 +126,80 @@ export default function CourseCard({ course, index, onEdit, onPreview, onAssign 
                 {difficultyLabels[course.difficulty] || course.difficulty}
               </Badge>
               {course.youtube_video_id && (
-                <Badge variant="outline" className="border-error/30 text-error bg-error/10">
-                  <Youtube className="w-3 h-3 mr-1" />
+                <Badge variant="outline" className="border-error/30 bg-error/10 text-error">
+                  <Youtube className="mr-1 h-3 w-3" />
                   {t("courseCard.youtube")}
                 </Badge>
               )}
               {course.file_url && (
-                <Badge variant="outline" className="border-brand/30 text-brand bg-brand/10">
-                  <FileText className="w-3 h-3 mr-1" />
+                <Badge variant="outline" className="border-brand/30 bg-brand/10 text-brand">
+                  <FileText className="mr-1 h-3 w-3" />
                   {course.file_name || t("common.misc.file")}
                 </Badge>
               )}
               {assignmentCount > 0 && (
-                <Badge variant="outline" className="border-brand2/30 text-brand2 bg-brand2/10">
-                  <Users className="w-3 h-3 mr-1" />
+                <Badge variant="outline" className="border-brand2/30 bg-brand2/10 text-brand2">
+                  <Users className="mr-1 h-3 w-3" />
                   {t(
                     "courseCard.active",
-                    '{{count}} active learner(s)',
-                    { count: assignmentCount },
+                    '{{count}} active learner{{suffix}}',
+                    {
+                      count: assignmentCount,
+                      suffix: assignmentCount === 1 ? '' : 's',
+                    },
                   )}
                 </Badge>
               )}
             </div>
 
-            <div className="flex items-center justify-between text-sm">
-              <div className="flex items-center gap-4">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-wrap items-center gap-4 text-sm text-muted">
                 {course.duration_hours && (
-                  <div className="flex items-center gap-1 text-muted">
-                    <Clock className="w-4 h-4" />
+                  <div className="flex items-center gap-1">
+                    <Clock className="h-4 w-4" />
                     <span>{course.duration_hours}h</span>
                   </div>
                 )}
                 {course.enrolled_count > 0 && (
-                  <div className="flex items-center gap-1 text-muted">
-                    <Users className="w-4 h-4" />
+                  <div className="flex items-center gap-1">
+                    <Users className="h-4 w-4" />
                     <span>{course.enrolled_count}</span>
+                  </div>
+                )}
+                {hasMedia && (
+                  <div className="flex items-center gap-1">
+                    <Eye className="h-4 w-4 text-brand" />
+                    <span className="text-xs uppercase tracking-wide text-brand">
+                      {t("courseCard.preview")}
+                    </span>
                   </div>
                 )}
               </div>
               {course.completion_rate > 0 && (
-                <div className="flex items-center gap-1 text-success">
-                  <TrendingUp className="w-4 h-4" />
-                  <span className="font-medium">{course.completion_rate}%</span>
+                <div className="inline-flex items-center gap-2 rounded-full bg-success/10 px-3 py-1 text-sm font-medium text-success">
+                  <TrendingUp className="h-4 w-4" />
+                  {course.completion_rate}%
                 </div>
               )}
             </div>
 
-            <div className="grid grid-cols-2 gap-2 pt-2">
+            <div className="grid gap-2 pt-1 sm:grid-cols-3">
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => onEdit(course)}
-                className="border-border hover:bg-surface2"
+                className="h-11 justify-center rounded-xl border-border/70 bg-surface2/80 text-primary transition-colors hover:border-brand/40 hover:bg-surface"
               >
-                <Pencil className="w-4 h-4 mr-2" />
+                <Pencil className="mr-2 h-4 w-4" />
                 {t("courseCard.edit")}
               </Button>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => onAssign(course)}
-                className="border-brand2/30 hover:bg-brand2/10 text-brand2"
+                className="h-11 justify-center rounded-xl border-brand2/40 bg-brand2/10 text-brand2 transition-colors hover:border-brand2/60 hover:bg-brand2/15"
               >
-                <UserPlus className="w-4 h-4 mr-2" />
+                <UserPlus className="mr-2 h-4 w-4" />
                 {t("courseCard.assign")}
               </Button>
               {hasMedia && (
@@ -169,9 +207,9 @@ export default function CourseCard({ course, index, onEdit, onPreview, onAssign 
                   variant="outline"
                   size="sm"
                   onClick={() => onPreview(course)}
-                  className="col-span-2 border-brand/30 hover:bg-brand/10 text-brand"
+                  className="h-11 justify-center rounded-xl border-brand/40 bg-brand/10 text-brand transition-colors hover:border-brand/60 hover:bg-brand/15"
                 >
-                  <Eye className="w-4 h-4 mr-2" />
+                  <Eye className="mr-2 h-4 w-4" />
                   {t("courseCard.preview")}
                 </Button>
               )}

--- a/Ascenda Padrinho att/src/components/i18n/LanguageToggle.jsx
+++ b/Ascenda Padrinho att/src/components/i18n/LanguageToggle.jsx
@@ -26,7 +26,17 @@ export default function LanguageToggle() {
             aria-label={option.label}
             title={option.label}
           >
-            <span aria-hidden="true">{option.emoji}</span>
+            <span
+              aria-hidden="true"
+              role="img"
+              className="leading-none"
+              style={{
+                fontFamily:
+                  '"Twemoji Country Flags", "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", sans-serif',
+              }}
+            >
+              {option.emoji}
+            </span>
           </button>
         );
       })}

--- a/Ascenda Padrinho att/src/i18n/translations/en.js
+++ b/Ascenda Padrinho att/src/i18n/translations/en.js
@@ -247,11 +247,37 @@ const en = {
   content: {
     title: "Content Management",
     subtitle: "Create and manage training materials for your team",
+    heroBadge: "Learning hub",
     libraryTitle: "Course Library",
-    courseCount: "{{count}} courses",
+    courseCount: "{{count}} course{{suffix}}",
     noCourses: "No courses yet. Create your first one!",
     empty: "No courses yet. Create your first one!",
-    addCourse: "Add New Course"
+    addCourse: "Add new course",
+    resultsCount: "Showing {{count}} course{{suffix}}",
+    filters: {
+      trainingType: "Training type",
+      trainingTypes: {
+        all: "All training types",
+      },
+      searchLabel: "Search courses",
+      searchPlaceholder: "Search by title or description",
+      clear: "Clear filters",
+      activeLabel: "Filtered by",
+    },
+    filteredCount: "{{count}} course{{suffix}} match this filter",
+    stats: {
+      totalHoursLabel: "Catalog hours",
+      totalHoursHint: "Hours of learning available",
+      averageCompletionLabel: "Avg. completion",
+      averageCompletionHint: "Across published courses",
+      activeLearnersLabel: "Active learners",
+      activeLearnersValue: "{{count}}",
+      activeLearnersHint: "Currently enrolled",
+    },
+    tips: {
+      title: "Share engaging learning journeys",
+      body: "Highlight why the course matters, include helpful materials, and preview before publishing to craft delightful learning experiences.",
+    },
   },
   courseForm: {
     titleLabel: "Course Title *",
@@ -284,8 +310,9 @@ const en = {
     }
   },
   courseCard: {
+    label: "Featured course",
     youtube: "YouTube",
-    active: "{{count}} active",
+    active: "{{count}} active learner{{suffix}}",
     edit: "Edit",
     assign: "Assign",
     preview: "Preview"

--- a/Ascenda Padrinho att/src/i18n/translations/pt.js
+++ b/Ascenda Padrinho att/src/i18n/translations/pt.js
@@ -247,11 +247,37 @@ const pt = {
   content: {
     title: "Gestão de conteúdo",
     subtitle: "Crie e gerencie materiais de treinamento para sua equipe",
+    heroBadge: "Central de aprendizagem",
     libraryTitle: "Biblioteca de cursos",
-    courseCount: "{{count}} cursos",
+    courseCount: "{{count}} curso{{suffix}}",
     noCourses: "Ainda não há cursos. Crie o primeiro!",
     empty: "Ainda não há cursos. Crie o primeiro!",
-    addCourse: "Adicionar novo curso"
+    addCourse: "Adicionar novo curso",
+    resultsCount: "Exibindo {{count}} curso{{suffix}}",
+    filters: {
+      trainingType: "Tipo de treinamento",
+      trainingTypes: {
+        all: "Todos os tipos",
+      },
+      searchLabel: "Buscar cursos",
+      searchPlaceholder: "Busque por título ou descrição",
+      clear: "Limpar filtros",
+      activeLabel: "Filtrado por",
+    },
+    filteredCount: "{{count}} curso{{suffix}} corresponde a este filtro",
+    stats: {
+      totalHoursLabel: "Horas em catálogo",
+      totalHoursHint: "Horas de aprendizado disponíveis",
+      averageCompletionLabel: "Média de conclusão",
+      averageCompletionHint: "Entre os cursos publicados",
+      activeLearnersLabel: "Aprendizes ativos",
+      activeLearnersValue: "{{count}}",
+      activeLearnersHint: "Atualmente matriculados",
+    },
+    tips: {
+      title: "Compartilhe jornadas envolventes",
+      body: "Explique o valor do curso, inclua materiais úteis e faça uma pré-visualização antes de publicar para entregar experiências de aprendizagem encantadoras.",
+    },
   },
   courseForm: {
     titleLabel: "Título do curso *",
@@ -284,8 +310,9 @@ const pt = {
     }
   },
   courseCard: {
+    label: "Curso em destaque",
     youtube: "YouTube",
-    active: "{{count}} ativo{{suffix}}",
+    active: "{{count}} pessoa{{suffix}} ativa{{suffix}}",
     edit: "Editar",
     assign: "Atribuir",
     preview: "Pré-visualizar"

--- a/Ascenda Padrinho att/src/pages/ContentManagement.jsx
+++ b/Ascenda Padrinho att/src/pages/ContentManagement.jsx
@@ -1,20 +1,17 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { Course } from "@/entities/Course";
 import { motion } from "framer-motion";
+import { Sparkles, Search, Filter, XCircle } from "lucide-react";
 import CourseUploadForm from "../components/content/CourseUploadForm";
 import CourseCard from "../components/content/CourseCard";
 import CourseEditModal from "../components/content/CourseEditModal";
 import PreviewDrawer from "../components/media/PreviewDrawer";
 import AssignCourseModal from "../components/courses/AssignCourseModal";
 import { useTranslation } from "../i18n";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useTrainingTypeOptions } from "@/utils/labels";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 
 export default function ContentManagement() {
   const [courses, setCourses] = useState([]);
@@ -25,6 +22,7 @@ export default function ContentManagement() {
   const [assigningCourse, setAssigningCourse] = useState(null);
   const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
   const [trainingFilter, setTrainingFilter] = useState("all");
+  const [searchTerm, setSearchTerm] = useState("");
   const { t } = useTranslation();
   const trainingOptions = useTrainingTypeOptions(t);
 
@@ -71,72 +69,272 @@ export default function ContentManagement() {
     loadCourses();
   }, [loadCourses]);
 
-  const filteredCourses = useMemo(
-    () =>
-      courses.filter((course) =>
-        trainingFilter === "all"
-          ? true
-          : course.training_type === trainingFilter
-      ),
-    [courses, trainingFilter]
+  const filteredCourses = useMemo(() => {
+    const normalizedTerm = searchTerm.trim().toLowerCase();
+
+    return courses.filter((course) => {
+      const matchesTraining =
+        trainingFilter === "all" || course.training_type === trainingFilter;
+      const matchesSearch =
+        normalizedTerm.length === 0 ||
+        [course.title, course.description]
+          .filter(Boolean)
+          .some((value) => value.toLowerCase().includes(normalizedTerm));
+
+      return matchesTraining && matchesSearch;
+    });
+  }, [courses, trainingFilter, searchTerm]);
+
+  const courseStats = useMemo(() => {
+    if (!courses.length) {
+      return {
+        totalHours: 0,
+        averageCompletion: 0,
+        activeLearners: 0,
+      };
+    }
+
+    const totalHours = courses.reduce(
+      (acc, course) => acc + (Number(course.duration_hours) || 0),
+      0
+    );
+
+    const completionValues = courses
+      .map((course) => Number(course.completion_rate) || 0)
+      .filter((value) => value > 0);
+    const averageCompletion =
+      completionValues.length > 0
+        ? completionValues.reduce((acc, value) => acc + value, 0) /
+          completionValues.length
+        : 0;
+
+    const activeLearners = courses.reduce(
+      (acc, course) => acc + (Number(course.enrolled_count) || 0),
+      0
+    );
+
+    return {
+      totalHours,
+      averageCompletion,
+      activeLearners,
+    };
+  }, [courses]);
+
+  const activeTrainingOption = trainingOptions.find(
+    (option) => option.value === trainingFilter
   );
 
+  const hasActiveFilters =
+    trainingFilter !== "all" || searchTerm.trim().length > 0;
+
   return (
-    <div className="min-h-screen p-6 md:p-8">
-      <div className="max-w-7xl mx-auto space-y-8">
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(55,110,255,0.12),_transparent_55%)] p-6 md:p-10">
+      <div className="mx-auto flex max-w-7xl flex-col gap-10">
+        <motion.section
+          initial={{ opacity: 0, y: -12 }}
           animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+          className="relative overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-surface/90 via-surface2/90 to-surface/95 p-8 shadow-e3"
         >
-          <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-            {t('content.title', 'Content Management')}
-          </h1>
-          <p className="text-muted">
-            {t('content.subtitle', 'Create and manage training materials for your team')}
-          </p>
-        </motion.div>
-
-        <div className="grid lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-1">
-            <CourseUploadForm 
-              onSuccess={handleCourseCreate}
-              onPreview={handleFormPreview}
-            />
-          </div>
-
-          <div className="lg:col-span-2 space-y-6">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <h2 className="text-2xl font-bold text-primary">
-                {t('content.libraryTitle', 'Course Library')}
-              </h2>
-              <div className="flex items-center gap-3">
-                <span className="text-sm text-muted">
-                  {t('content.courseCount', '{{count}} courses', { count: courses.length })}
-                </span>
-                <Select value={trainingFilter} onValueChange={setTrainingFilter}>
-                  <SelectTrigger className="w-48 bg-surface2 border-border text-primary">
-                    <SelectValue placeholder={t('content.filters.trainingType', 'Training type')} />
-                  </SelectTrigger>
-                  <SelectContent className="bg-surface border-border">
-                    {trainingOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+          <div className="absolute inset-x-6 top-0 h-px bg-gradient-to-r from-brand via-brand2/70 to-brand" />
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-4">
+              <span className="inline-flex items-center gap-2 rounded-full bg-brand/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-brand">
+                <Sparkles className="h-4 w-4" />
+                {t('content.heroBadge', 'Learning hub')}
+              </span>
+              <div className="space-y-2">
+                <h1 className="text-3xl font-bold text-primary md:text-4xl">
+                  {t('content.title', 'Content Management')}
+                </h1>
+                <p className="max-w-2xl text-base text-muted md:text-lg">
+                  {t(
+                    'content.subtitle',
+                    'Create and manage training materials for your team'
+                  )}
+                </p>
               </div>
             </div>
 
-            {trainingFilter !== "all" && (
-              <p className="text-xs text-muted">
+            <div className="grid w-full gap-4 sm:grid-cols-3 lg:w-auto">
+              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted">
+                  {t('content.stats.totalHoursLabel', 'Catalog hours')}
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-primary">
+                  {new Intl.NumberFormat().format(
+                    Math.round(courseStats.totalHours)
+                  )}
+                </p>
+                <p className="text-xs text-muted">
+                  {t('content.stats.totalHoursHint', 'Hours of learning available')}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted">
+                  {t('content.stats.averageCompletionLabel', 'Avg. completion')}
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-primary">
+                  {courseStats.averageCompletion.toFixed(0)}%
+                </p>
+                <p className="text-xs text-muted">
+                  {t('content.stats.averageCompletionHint', 'Across published courses')}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted">
+                  {t('content.stats.activeLearnersLabel', 'Active learners')}
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-primary">
+                  {t('content.stats.activeLearnersValue', '{{count}}', {
+                    count: new Intl.NumberFormat().format(
+                      courseStats.activeLearners
+                    ),
+                  })}
+                </p>
+                <p className="text-xs text-muted">
+                  {t('content.stats.activeLearnersHint', 'Currently enrolled')}
+                </p>
+              </div>
+            </div>
+          </div>
+        </motion.section>
+
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)] xl:gap-10">
+          <div className="space-y-6 lg:sticky lg:top-10 lg:h-fit">
+            <CourseUploadForm
+              onSuccess={handleCourseCreate}
+              onPreview={handleFormPreview}
+            />
+
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1 }}
+              className="rounded-3xl border border-border/60 bg-surface2/80 p-6 shadow-e1"
+            >
+              <h3 className="text-lg font-semibold text-primary">
+                {t('content.tips.title', 'Share engaging learning journeys')}
+              </h3>
+              <p className="mt-2 text-sm text-muted">
                 {t(
-                  'content.filteredCount',
-                  '{{count}} course(s) match this filter',
-                  { count: filteredCourses.length },
+                  'content.tips.body',
+                  'Highlight why the course matters, include helpful materials, and preview before publishing to craft delightful learning experiences.'
                 )}
               </p>
-            )}
+            </motion.div>
+          </div>
+
+          <div className="space-y-6">
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.08 }}
+              className="rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm"
+            >
+              <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+                <Filter className="h-4 w-4" />
+                {t('content.libraryTitle', 'Course Library')}
+              </div>
+              <div className="mt-4 flex flex-col gap-6 md:gap-8">
+                <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="course-search"
+                      className="text-xs font-medium uppercase tracking-wide text-muted"
+                    >
+                      {t('content.filters.searchLabel', 'Search courses')}
+                    </label>
+                    <div className="relative">
+                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
+                      <Input
+                        id="course-search"
+                        value={searchTerm}
+                        onChange={(event) => setSearchTerm(event.target.value)}
+                        placeholder={t(
+                          'content.filters.searchPlaceholder',
+                          'Search by title or description'
+                        )}
+                        className="h-11 rounded-2xl border-border/60 bg-surface2/70 pl-10 text-sm text-primary placeholder:text-muted"
+                      />
+                    </div>
+                  </div>
+
+                  {hasActiveFilters && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="justify-center gap-2 rounded-full border border-transparent bg-surface2/70 px-4 py-2 text-sm text-secondary hover:border-border/60 hover:bg-surface2"
+                      onClick={() => {
+                        setTrainingFilter("all");
+                        setSearchTerm("");
+                      }}
+                    >
+                      <XCircle className="h-4 w-4" />
+                      {t('content.filters.clear', 'Clear filters')}
+                    </Button>
+                  )}
+                </div>
+
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted">
+                    {t('content.filters.trainingType', 'Training type')}
+                  </p>
+                  <div
+                    className="mt-2 flex flex-wrap gap-2 rounded-2xl border border-border/60 bg-surface2/60 p-2"
+                    role="group"
+                    aria-label={t('content.filters.trainingType', 'Training type')}
+                  >
+                    {trainingOptions.map((option) => {
+                      const isActive = trainingFilter === option.value;
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          onClick={() => setTrainingFilter(option.value)}
+                          className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
+                            isActive
+                              ? 'border-brand bg-brand text-white shadow-e2'
+                              : 'border-transparent bg-transparent text-secondary hover:border-brand/40 hover:bg-brand/5 hover:text-primary'
+                          }`}
+                          aria-pressed={isActive}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-3 text-xs text-muted">
+                  <Badge className="rounded-full border border-brand/30 bg-brand/10 text-brand">
+                    {t(
+                      'content.courseCount',
+                      '{{count}} course{{suffix}}',
+                      {
+                        count: courses.length,
+                        suffix: courses.length === 1 ? '' : 's',
+                      }
+                    )}
+                  </Badge>
+                  <span>
+                    {t(
+                      'content.resultsCount',
+                      'Showing {{count}} course{{suffix}}',
+                      {
+                        count: filteredCourses.length,
+                        suffix: filteredCourses.length === 1 ? '' : 's',
+                      }
+                    )}
+                  </span>
+                  {trainingFilter !== "all" && activeTrainingOption && (
+                    <span className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-surface2 px-3 py-1 text-xs text-secondary">
+                      {t('content.filters.activeLabel', 'Filtered by')} {activeTrainingOption.label}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </motion.div>
 
             <div className="grid gap-6">
               {filteredCourses.map((course, index) => (
@@ -152,11 +350,15 @@ export default function ContentManagement() {
             </div>
 
             {filteredCourses.length === 0 && (
-              <div className="text-center py-12 bg-surface2 border border-border rounded-xl">
-                <p className="text-muted">
+              <motion.div
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-3xl border border-dashed border-border/60 bg-surface/60 p-12 text-center"
+              >
+                <p className="text-sm text-muted">
                   {t('content.empty', 'No courses yet. Create your first one!')}
                 </p>
-              </div>
+              </motion.div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reorganize the content management page with a new hero, filter card, and search to improve clarity
- refresh course cards with richer visual hierarchy and hover treatments
- add English and Portuguese copy for the updated interface text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e022349518832d87be938f725f740a