### PR TITLE
Fix ContentManagement JSX closing tag mismatch

### DIFF
--- a/Ascenda Padrinho att/src/pages/ContentManagement.jsx
+++ b/Ascenda Padrinho att/src/pages/ContentManagement.jsx
@@ -241,7 +241,6 @@ export default function ContentManagement() {
               </div>
             </div>
           </div>
-        </motion.section>
 
         <div className="grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)] xl:gap-10">
           <div className="space-y-6 lg:sticky lg:top-10 lg:h-fit">


### PR DESCRIPTION
## Summary
- remove the stray </motion.section> closing tag in ContentManagement that lacked a matching opener and broke the JSX parse step

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5a3ffa84c832dadfb694f588be329