### PR TITLE
Revamp ContentManagement layout

### DIFF
--- a/Ascenda Padrinho att/src/pages/ContentManagement.jsx
+++ b/Ascenda Padrinho att/src/pages/ContentManagement.jsx
@@ -143,107 +143,7 @@ export default function ContentManagement() {
           </p>
         </motion.div>
 
-        <div className="grid lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-1">
-            <CourseUploadForm 
-              onSuccess={handleCourseCreate}
-              onPreview={handleFormPreview}
-            />
-          </div>
-
-          <div className="lg:col-span-2 space-y-6">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <h2 className="text-2xl font-bold text-primary">
-                {t('content.libraryTitle', 'Course Library')}
-              </h2>
-              <div className="w-full lg:w-auto space-y-2">
-                <p className="text-sm text-muted">
-                  {t(
-                    'content.courseCount',
-                    '{{count}} course{{suffix}}',
-                    {
-                      count: courses.length,
-                      suffix: courses.length === 1 ? '' : 's',
-                    },
-                  )}
-                </p>
-                <div>
-                  <p className="text-xs font-medium uppercase tracking-wide text-muted">
-                    {t('content.filters.trainingType', 'Training type')}
-                  </p>
-                  <div
-                    className="mt-2 flex flex-wrap gap-2 rounded-2xl border border-border bg-surface2/80 p-2"
-                    role="group"
-                    aria-label={t('content.filters.trainingType', 'Training type')}
-                  >
-                    {trainingOptions.map((option) => {
-                      const isActive = trainingFilter === option.value;
-                      return (
-                        <button
-                          key={option.value}
-                          type="button"
-                          onClick={() => setTrainingFilter(option.value)}
-                          className={`rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
-                            isActive
-                              ? 'border-brand bg-brand text-white shadow-e1'
-                              : 'border-border/60 bg-surface text-secondary hover:border-brand/60 hover:text-primary'
-                          }`}
-                          aria-pressed={isActive}
-                        >
-                          {option.label}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="grid w-full gap-4 sm:grid-cols-3 lg:w-auto">
-              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4">
-                <p className="text-xs uppercase tracking-wide text-muted">
-                  {t('content.stats.totalHoursLabel', 'Catalog hours')}
-                </p>
-                <p className="mt-2 text-2xl font-semibold text-primary">
-                  {new Intl.NumberFormat().format(
-                    Math.round(courseStats.totalHours)
-                  )}
-                </p>
-                <p className="text-xs text-muted">
-                  {t('content.stats.totalHoursHint', 'Hours of learning available')}
-                </p>
-              </div>
-              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4">
-                <p className="text-xs uppercase tracking-wide text-muted">
-                  {t('content.stats.averageCompletionLabel', 'Avg. completion')}
-                </p>
-                <p className="mt-2 text-2xl font-semibold text-primary">
-                  {courseStats.averageCompletion.toFixed(0)}%
-                </p>
-                <p className="text-xs text-muted">
-                  {t('content.stats.averageCompletionHint', 'Across published courses')}
-                </p>
-              </div>
-              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4">
-                <p className="text-xs uppercase tracking-wide text-muted">
-                  {t('content.stats.activeLearnersLabel', 'Active learners')}
-                </p>
-                <p className="mt-2 text-2xl font-semibold text-primary">
-                  {t('content.stats.activeLearnersValue', '{{count}}', {
-                    count: new Intl.NumberFormat().format(
-                      courseStats.activeLearners
-                    ),
-                  })}
-                </p>
-                <p className="text-xs text-muted">
-                  {t('content.stats.activeLearnersHint', 'Currently enrolled')}
-                </p>
-              </div>
-            </div>
-          </div>
-        </motion.section>
-
-        <div className="grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)] xl:gap-10">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.55fr)] xl:gap-12">
           <div className="space-y-6 lg:sticky lg:top-10 lg:h-fit">
             <CourseUploadForm
               onSuccess={handleCourseCreate}
@@ -256,34 +156,106 @@ export default function ContentManagement() {
               transition={{ delay: 0.1 }}
               className="rounded-3xl border border-border/60 bg-surface2/80 p-6 shadow-e1"
             >
-              <h3 className="text-lg font-semibold text-primary">
-                {t('content.tips.title', 'Share engaging learning journeys')}
-              </h3>
-              <p className="mt-2 text-sm text-muted">
-                {t(
-                  'content.filteredCount',
-                  '{{count}} course{{suffix}} match this filter',
-                  {
-                    count: filteredCourses.length,
-                    suffix: filteredCourses.length === 1 ? '' : 's',
-                  },
-                )}
-              </p>
+              <div className="flex items-start gap-3">
+                <Sparkles className="mt-1 h-5 w-5 text-brand" />
+                <div>
+                  <h3 className="text-lg font-semibold text-primary">
+                    {t('content.tips.title', 'Share engaging learning journeys')}
+                  </h3>
+                  <p className="mt-2 text-sm text-muted">
+                    {t(
+                      'content.filteredCount',
+                      '{{count}} course{{suffix}} match this filter',
+                      {
+                        count: filteredCourses.length,
+                        suffix: filteredCourses.length === 1 ? '' : 's',
+                      },
+                    )}
+                  </p>
+                </div>
+              </div>
             </motion.div>
           </div>
 
-          <div className="space-y-6">
+          <div className="space-y-8">
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.05 }}
+              className="rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm"
+            >
+              <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+                <div className="space-y-2">
+                  <div className="inline-flex items-center gap-2 text-sm font-semibold text-primary">
+                    <Filter className="h-4 w-4" />
+                    {t('content.libraryTitle', 'Course Library')}
+                  </div>
+                  <h2 className="text-2xl font-bold text-primary">
+                    {t('content.librarySubtitle', 'Curate and publish impactful learning')}
+                  </h2>
+                  <p className="text-sm text-muted">
+                    {t(
+                      'content.courseCount',
+                      '{{count}} course{{suffix}} ready for your team',
+                      {
+                        count: courses.length,
+                        suffix: courses.length === 1 ? '' : 's',
+                      },
+                    )}
+                  </p>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2 xl:min-w-[24rem] xl:grid-cols-3">
+                  <div className="rounded-2xl border border-border/50 bg-surface2/80 p-4">
+                    <p className="text-xs uppercase tracking-wide text-muted">
+                      {t('content.stats.totalHoursLabel', 'Catalog hours')}
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold text-primary">
+                      {new Intl.NumberFormat().format(
+                        Math.round(courseStats.totalHours)
+                      )}
+                    </p>
+                    <p className="text-xs text-muted">
+                      {t('content.stats.totalHoursHint', 'Hours of learning available')}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-border/50 bg-surface2/80 p-4">
+                    <p className="text-xs uppercase tracking-wide text-muted">
+                      {t('content.stats.averageCompletionLabel', 'Avg. completion')}
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold text-primary">
+                      {courseStats.averageCompletion.toFixed(0)}%
+                    </p>
+                    <p className="text-xs text-muted">
+                      {t('content.stats.averageCompletionHint', 'Across published courses')}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-border/50 bg-surface2/80 p-4">
+                    <p className="text-xs uppercase tracking-wide text-muted">
+                      {t('content.stats.activeLearnersLabel', 'Active learners')}
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold text-primary">
+                      {t('content.stats.activeLearnersValue', '{{count}}', {
+                        count: new Intl.NumberFormat().format(
+                          courseStats.activeLearners
+                        ),
+                      })}
+                    </p>
+                    <p className="text-xs text-muted">
+                      {t('content.stats.activeLearnersHint', 'Currently enrolled')}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </motion.div>
+
             <motion.div
               initial={{ opacity: 0, y: 16 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.08 }}
               className="rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm"
             >
-              <div className="flex items-center gap-2 text-sm font-semibold text-primary">
-                <Filter className="h-4 w-4" />
-                {t('content.libraryTitle', 'Course Library')}
-              </div>
-              <div className="mt-4 flex flex-col gap-6 md:gap-8">
+              <div className="flex flex-col gap-6">
                 <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
                   <div className="space-y-2">
                     <label
@@ -323,40 +295,41 @@ export default function ContentManagement() {
                   )}
                 </div>
 
-                <div>
-                  <p className="text-xs font-medium uppercase tracking-wide text-muted">
-                    {t('content.filters.trainingType', 'Training type')}
-                  </p>
-                  <div
-                    className="mt-2 flex flex-wrap gap-2 rounded-2xl border border-border/60 bg-surface2/60 p-2"
-                    role="group"
-                    aria-label={t('content.filters.trainingType', 'Training type')}
-                  >
-                    {trainingOptions.map((option) => {
-                      const isActive = trainingFilter === option.value;
-                      return (
-                        <button
-                          key={option.value}
-                          type="button"
-                          onClick={() => setTrainingFilter(option.value)}
-                          className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
-                            isActive
-                              ? 'border-brand bg-brand text-white shadow-e2'
-                              : 'border-transparent bg-transparent text-secondary hover:border-brand/40 hover:bg-brand/5 hover:text-primary'
-                          }`}
-                          aria-pressed={isActive}
-                        >
-                          {option.label}
-                        </button>
-                      );
-                    })}
+                <div className="space-y-3">
+                  <div>
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted">
+                      {t('content.filters.trainingType', 'Training type')}
+                    </p>
+                    <div
+                      className="mt-2 flex flex-wrap gap-2 rounded-2xl border border-border/60 bg-surface2/60 p-2"
+                      role="group"
+                      aria-label={t('content.filters.trainingType', 'Training type')}
+                    >
+                      {trainingOptions.map((option) => {
+                        const isActive = trainingFilter === option.value;
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() => setTrainingFilter(option.value)}
+                            className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
+                              isActive
+                                ? 'border-brand bg-brand text-white shadow-e2'
+                                : 'border-transparent bg-transparent text-secondary hover:border-brand/40 hover:bg-brand/5 hover:text-primary'
+                            }`}
+                            aria-pressed={isActive}
+                          >
+                            {option.label}
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
 
-                <div className="flex flex-wrap items-center gap-3 text-xs text-muted">
-                  <Badge className="rounded-full border border-brand/30 bg-brand/10 text-brand">
-                    {t(
-                      'content.courseCount',
+                  <div className="flex flex-wrap items-center gap-3 text-xs text-muted">
+                    <Badge className="rounded-full border border-brand/30 bg-brand/10 text-brand">
+                      {t(
+                        'content.courseCount',
                       '{{count}} course{{suffix}}',
                       {
                         count: courses.length,
@@ -374,11 +347,12 @@ export default function ContentManagement() {
                       }
                     )}
                   </span>
-                  {trainingFilter !== "all" && activeTrainingOption && (
-                    <span className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-surface2 px-3 py-1 text-xs text-secondary">
-                      {t('content.filters.activeLabel', 'Filtered by')} {activeTrainingOption.label}
-                    </span>
-                  )}
+                    {trainingFilter !== "all" && activeTrainingOption && (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-surface2 px-3 py-1 text-xs text-secondary">
+                        {t('content.filters.activeLabel', 'Filtered by')} {activeTrainingOption.label}
+                      </span>
+                    )}
+                  </div>
                 </div>
               </div>
             </motion.div>


### PR DESCRIPTION
## Summary
- consolidate the ContentManagement grid into a single two-column layout so the upload form and library stay aligned
- refresh the library header and stats presentation to improve spacing and readability across breakpoints
- add contextual tip styling with iconography to better balance the sidebar content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5a3ffa84c832dadfb694f588be329