### PR TITLE
Rewrite ContentManagement layout to remove motion remnants

### DIFF
--- a/Ascenda Padrinho att/src/pages/ContentManagement.jsx
+++ b/Ascenda Padrinho att/src/pages/ContentManagement.jsx
@@ -1,13 +1,17 @@
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { Filter, Search, Sparkles, XCircle } from "lucide-react";
+
 import { Course } from "@/entities/Course";
-import { motion } from "framer-motion";
-import { Sparkles, Search, Filter, XCircle } from "lucide-react";
 import CourseUploadForm from "../components/content/CourseUploadForm";
 import CourseCard from "../components/content/CourseCard";
 import CourseEditModal from "../components/content/CourseEditModal";
 import PreviewDrawer from "../components/media/PreviewDrawer";
 import AssignCourseModal from "../components/courses/AssignCourseModal";
-import LibraryFilterCard from "../components/content/LibraryFilterCard";
 import { useTranslation } from "../i18n";
 import { useTrainingTypeOptions } from "@/utils/labels";
 import { Input } from "@/components/ui/input";
@@ -15,20 +19,25 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 
 export default function ContentManagement() {
+  const { t } = useTranslation();
+
   const [courses, setCourses] = useState([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [trainingFilter, setTrainingFilter] = useState("all");
+
   const [editingCourse, setEditingCourse] = useState(null);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+
   const [previewCourse, setPreviewCourse] = useState(null);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
   const [assigningCourse, setAssigningCourse] = useState(null);
   const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
-  const [trainingFilter, setTrainingFilter] = useState("all");
-  const [searchTerm, setSearchTerm] = useState("");
-  const { t } = useTranslation();
+
   const trainingOptions = useTrainingTypeOptions(t);
 
   const loadCourses = useCallback(async () => {
-    const data = await Course.list('-created_date');
+    const data = await Course.list("-created_date");
     setCourses(data);
   }, []);
 
@@ -36,20 +45,26 @@ export default function ContentManagement() {
     loadCourses();
   }, [loadCourses]);
 
-  const handleCourseCreate = useCallback(async (courseData) => {
-    await Course.create(courseData);
-    loadCourses();
-  }, [loadCourses]);
+  const handleCourseCreate = useCallback(
+    async (courseData) => {
+      await Course.create(courseData);
+      loadCourses();
+    },
+    [loadCourses],
+  );
 
   const handleEdit = useCallback((course) => {
     setEditingCourse(course);
     setIsEditModalOpen(true);
   }, []);
 
-  const handleSaveEdit = useCallback(async (updatedData) => {
-    await Course.update(editingCourse.id, updatedData);
-    loadCourses();
-  }, [editingCourse, loadCourses]);
+  const handleSaveEdit = useCallback(
+    async (updatedData) => {
+      await Course.update(editingCourse.id, updatedData);
+      loadCourses();
+    },
+    [editingCourse, loadCourses],
+  );
 
   const handlePreview = useCallback((course) => {
     setPreviewCourse(course);
@@ -84,10 +99,10 @@ export default function ContentManagement() {
 
       return matchesTraining && matchesSearch;
     });
-  }, [courses, trainingFilter, searchTerm]);
+  }, [courses, searchTerm, trainingFilter]);
 
   const courseStats = useMemo(() => {
-    if (!courses.length) {
+    if (courses.length === 0) {
       return {
         totalHours: 0,
         averageCompletion: 0,
@@ -97,12 +112,13 @@ export default function ContentManagement() {
 
     const totalHours = courses.reduce(
       (acc, course) => acc + (Number(course.duration_hours) || 0),
-      0
+      0,
     );
 
     const completionValues = courses
       .map((course) => Number(course.completion_rate) || 0)
       .filter((value) => value > 0);
+
     const averageCompletion =
       completionValues.length > 0
         ? completionValues.reduce((acc, value) => acc + value, 0) /
@@ -111,7 +127,7 @@ export default function ContentManagement() {
 
     const activeLearners = courses.reduce(
       (acc, course) => acc + (Number(course.enrolled_count) || 0),
-      0
+      0,
     );
 
     return {
@@ -121,315 +137,335 @@ export default function ContentManagement() {
     };
   }, [courses]);
 
-  const activeTrainingOption = trainingOptions.find(
-    (option) => option.value === trainingFilter
+  const activeTrainingOption = useMemo(
+    () => trainingOptions.find((option) => option.value === trainingFilter),
+    [trainingOptions, trainingFilter],
   );
 
   const hasActiveFilters =
     trainingFilter !== "all" || searchTerm.trim().length > 0;
 
   return (
-    <div className="min-h-screen p-6 md:p-8">
-      <div className="max-w-7xl mx-auto space-y-8">
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-        >
-          <h1 className="text-3xl md:text-4xl font-bold text-primary mb-2">
-            {t('content.title', 'Content Management')}
+    <main className="min-h-screen bg-surface/30 px-6 py-8 md:px-10">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold text-primary md:text-4xl">
+            {t("content.title", "Content Management")}
           </h1>
-          <p className="text-muted">
-            {t('content.subtitle', 'Create and manage training materials for your team')}
+          <p className="max-w-2xl text-sm text-muted md:text-base">
+            {t(
+              "content.subtitle",
+              "Create and manage training materials for your team",
+            )}
           </p>
-        </motion.div>
+        </header>
 
-        <div className="grid lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-1">
-            <CourseUploadForm 
-              onSuccess={handleCourseCreate}
-              onPreview={handleFormPreview}
-            />
-          </div>
-
-          <div className="lg:col-span-2 space-y-6">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <h2 className="text-2xl font-bold text-primary">
-                {t('content.libraryTitle', 'Course Library')}
-              </h2>
-              <div className="w-full lg:w-auto space-y-2">
-                <p className="text-sm text-muted">
-                  {t(
-                    'content.courseCount',
-                    '{{count}} course{{suffix}}',
-                    {
-                      count: courses.length,
-                      suffix: courses.length === 1 ? '' : 's',
-                    },
-                  )}
-                </p>
-                <div>
-                  <p className="text-xs font-medium uppercase tracking-wide text-muted">
-                    {t('content.filters.trainingType', 'Training type')}
-                  </p>
-                  <div
-                    className="mt-2 flex flex-wrap gap-2 rounded-2xl border border-border bg-surface2/80 p-2"
-                    role="group"
-                    aria-label={t('content.filters.trainingType', 'Training type')}
-                  >
-                    {trainingOptions.map((option) => {
-                      const isActive = trainingFilter === option.value;
-                      return (
-                        <button
-                          key={option.value}
-                          type="button"
-                          onClick={() => setTrainingFilter(option.value)}
-                          className={`rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
-                            isActive
-                              ? 'border-brand bg-brand text-white shadow-e1'
-                              : 'border-border/60 bg-surface text-secondary hover:border-brand/60 hover:text-primary'
-                          }`}
-                          aria-pressed={isActive}
-                        >
-                          {option.label}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="grid w-full gap-4 sm:grid-cols-3 lg:w-auto">
-              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4">
-                <p className="text-xs uppercase tracking-wide text-muted">
-                  {t('content.stats.totalHoursLabel', 'Catalog hours')}
-                </p>
-                <p className="mt-2 text-2xl font-semibold text-primary">
-                  {new Intl.NumberFormat().format(
-                    Math.round(courseStats.totalHours)
-                  )}
-                </p>
-                <p className="text-xs text-muted">
-                  {t('content.stats.totalHoursHint', 'Hours of learning available')}
-                </p>
-              </div>
-              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4">
-                <p className="text-xs uppercase tracking-wide text-muted">
-                  {t('content.stats.averageCompletionLabel', 'Avg. completion')}
-                </p>
-                <p className="mt-2 text-2xl font-semibold text-primary">
-                  {courseStats.averageCompletion.toFixed(0)}%
-                </p>
-                <p className="text-xs text-muted">
-                  {t('content.stats.averageCompletionHint', 'Across published courses')}
-                </p>
-              </div>
-              <div className="rounded-2xl border border-border/50 bg-surface/70 p-4">
-                <p className="text-xs uppercase tracking-wide text-muted">
-                  {t('content.stats.activeLearnersLabel', 'Active learners')}
-                </p>
-                <p className="mt-2 text-2xl font-semibold text-primary">
-                  {t('content.stats.activeLearnersValue', '{{count}}', {
-                    count: new Intl.NumberFormat().format(
-                      courseStats.activeLearners
-                    ),
-                  })}
-                </p>
-                <p className="text-xs text-muted">
-                  {t('content.stats.activeLearnersHint', 'Currently enrolled')}
-                </p>
-              </div>
-            </div>
-          </div>
-        </motion.section>
-
-        <div className="grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)] xl:gap-10">
-          <div className="space-y-6 lg:sticky lg:top-10 lg:h-fit">
+        <div className="flex flex-col gap-8 lg:flex-row">
+          <div className="flex w-full flex-col gap-6 lg:w-[380px] lg:shrink-0">
             <CourseUploadForm
               onSuccess={handleCourseCreate}
               onPreview={handleFormPreview}
             />
 
-            <motion.div
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1 }}
-              className="rounded-3xl border border-border/60 bg-surface2/80 p-6 shadow-e1"
-            >
-              <h3 className="text-lg font-semibold text-primary">
-                {t('content.tips.title', 'Share engaging learning journeys')}
-              </h3>
-              <p className="mt-2 text-sm text-muted">
-                {t(
-                  'content.filteredCount',
-                  '{{count}} course{{suffix}} match this filter',
-                  {
-                    count: filteredCourses.length,
-                    suffix: filteredCourses.length === 1 ? '' : 's',
-                  },
-                )}
-              </p>
-            </motion.div>
+            <TipsCard
+              t={t}
+              filteredCourses={filteredCourses.length}
+            />
           </div>
 
-          <div className="space-y-6">
-            <motion.div
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.08 }}
-              className="rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm"
-            >
-              <div className="flex items-center gap-2 text-sm font-semibold text-primary">
-                <Filter className="h-4 w-4" />
-                {t('content.libraryTitle', 'Course Library')}
-              </div>
-              <div className="mt-4 flex flex-col gap-6 md:gap-8">
-                <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-                  <div className="space-y-2">
-                    <label
-                      htmlFor="course-search"
-                      className="text-xs font-medium uppercase tracking-wide text-muted"
-                    >
-                      {t('content.filters.searchLabel', 'Search courses')}
-                    </label>
-                    <div className="relative">
-                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
-                      <Input
-                        id="course-search"
-                        value={searchTerm}
-                        onChange={(event) => setSearchTerm(event.target.value)}
-                        placeholder={t(
-                          'content.filters.searchPlaceholder',
-                          'Search by title or description'
-                        )}
-                        className="h-11 rounded-2xl border-border/60 bg-surface2/70 pl-10 text-sm text-primary placeholder:text-muted"
-                      />
-                    </div>
-                  </div>
+          <div className="flex flex-1 flex-col gap-8">
+            <LibrarySummary t={t} courses={courses} courseStats={courseStats} />
 
-                  {hasActiveFilters && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      className="justify-center gap-2 rounded-full border border-transparent bg-surface2/70 px-4 py-2 text-sm text-secondary hover:border-border/60 hover:bg-surface2"
-                      onClick={() => {
-                        setTrainingFilter("all");
-                        setSearchTerm("");
-                      }}
-                    >
-                      <XCircle className="h-4 w-4" />
-                      {t('content.filters.clear', 'Clear filters')}
-                    </Button>
-                  )}
-                </div>
+            <FiltersSection
+              t={t}
+              searchTerm={searchTerm}
+              setSearchTerm={setSearchTerm}
+              trainingFilter={trainingFilter}
+              setTrainingFilter={setTrainingFilter}
+              hasActiveFilters={hasActiveFilters}
+              trainingOptions={trainingOptions}
+              activeTrainingOption={activeTrainingOption}
+              courses={courses}
+              filteredCount={filteredCourses.length}
+            />
 
-                <div>
-                  <p className="text-xs font-medium uppercase tracking-wide text-muted">
-                    {t('content.filters.trainingType', 'Training type')}
-                  </p>
-                  <div
-                    className="mt-2 flex flex-wrap gap-2 rounded-2xl border border-border/60 bg-surface2/60 p-2"
-                    role="group"
-                    aria-label={t('content.filters.trainingType', 'Training type')}
-                  >
-                    {trainingOptions.map((option) => {
-                      const isActive = trainingFilter === option.value;
-                      return (
-                        <button
-                          key={option.value}
-                          type="button"
-                          onClick={() => setTrainingFilter(option.value)}
-                          className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface ${
-                            isActive
-                              ? 'border-brand bg-brand text-white shadow-e2'
-                              : 'border-transparent bg-transparent text-secondary hover:border-brand/40 hover:bg-brand/5 hover:text-primary'
-                          }`}
-                          aria-pressed={isActive}
-                        >
-                          {option.label}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-
-                <div className="flex flex-wrap items-center gap-3 text-xs text-muted">
-                  <Badge className="rounded-full border border-brand/30 bg-brand/10 text-brand">
-                    {t(
-                      'content.courseCount',
-                      '{{count}} course{{suffix}}',
-                      {
-                        count: courses.length,
-                        suffix: courses.length === 1 ? '' : 's',
-                      }
-                    )}
-                  </Badge>
-                  <span>
-                    {t(
-                      'content.resultsCount',
-                      'Showing {{count}} course{{suffix}}',
-                      {
-                        count: filteredCourses.length,
-                        suffix: filteredCourses.length === 1 ? '' : 's',
-                      }
-                    )}
-                  </span>
-                  {trainingFilter !== "all" && activeTrainingOption && (
-                    <span className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-surface2 px-3 py-1 text-xs text-secondary">
-                      {t('content.filters.activeLabel', 'Filtered by')} {activeTrainingOption.label}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </motion.div>
-
-            <div className="grid gap-6">
-              {filteredCourses.map((course, index) => (
-                <CourseCard
-                  key={course.id}
-                  course={course}
-                  index={index}
-                  onEdit={handleEdit}
-                  onPreview={handlePreview}
-                  onAssign={handleAssign}
-                />
-              ))}
-            </div>
-
-            {filteredCourses.length === 0 && (
-              <motion.div
-                initial={{ opacity: 0, y: 12 }}
-                animate={{ opacity: 1, y: 0 }}
-                className="rounded-3xl border border-dashed border-border/60 bg-surface/60 p-12 text-center"
-              >
-                <p className="text-sm text-muted">
-                  {t('content.empty', 'No courses yet. Create your first one!')}
-                </p>
-              </motion.div>
-            )}
+            <CourseList
+              courses={filteredCourses}
+              onEdit={handleEdit}
+              onPreview={handlePreview}
+              onAssign={handleAssign}
+              emptyMessage={t(
+                "content.empty",
+                "No courses yet. Create your first one!",
+              )}
+            />
           </div>
         </div>
-
-        <CourseEditModal
-          course={editingCourse}
-          isOpen={isEditModalOpen}
-          onClose={() => setIsEditModalOpen(false)}
-          onSave={handleSaveEdit}
-        />
-
-        <PreviewDrawer
-          isOpen={isPreviewOpen}
-          onClose={() => setIsPreviewOpen(false)}
-          course={previewCourse}
-        />
-
-        <AssignCourseModal
-          course={assigningCourse}
-          isOpen={isAssignModalOpen}
-          onClose={() => setIsAssignModalOpen(false)}
-          onSuccess={handleAssignSuccess}
-        />
       </div>
+
+      <CourseEditModal
+        course={editingCourse}
+        isOpen={isEditModalOpen}
+        onClose={() => setIsEditModalOpen(false)}
+        onSave={handleSaveEdit}
+      />
+
+      <PreviewDrawer
+        isOpen={isPreviewOpen}
+        onClose={() => setIsPreviewOpen(false)}
+        course={previewCourse}
+      />
+
+      <AssignCourseModal
+        course={assigningCourse}
+        isOpen={isAssignModalOpen}
+        onClose={() => setIsAssignModalOpen(false)}
+        onSuccess={handleAssignSuccess}
+      />
+    </main>
+  );
+}
+
+function TipsCard({ t, filteredCourses }) {
+  return (
+    <div className="rounded-3xl border border-border/60 bg-surface2/90 p-6 shadow-e1">
+      <div className="flex items-start gap-3">
+        <Sparkles className="mt-1 h-5 w-5 text-brand" />
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold text-primary">
+            {t("content.tips.title", "Share engaging learning journeys")}
+          </h2>
+          <p className="text-sm text-muted">
+            {t(
+              "content.filteredCount",
+              "{{count}} course{{suffix}} match this filter",
+              {
+                count: filteredCourses,
+                suffix: filteredCourses === 1 ? "" : "s",
+              },
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LibrarySummary({ t, courses, courseStats }) {
+  return (
+    <section className="rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <div className="inline-flex items-center gap-2 text-sm font-semibold text-primary">
+            <Filter className="h-4 w-4" />
+            {t("content.libraryTitle", "Course Library")}
+          </div>
+          <h2 className="text-2xl font-bold text-primary">
+            {t(
+              "content.librarySubtitle",
+              "Curate and publish impactful learning",
+            )}
+          </h2>
+          <p className="text-sm text-muted">
+            {t(
+              "content.courseCount",
+              "{{count}} course{{suffix}} ready for your team",
+              {
+                count: courses.length,
+                suffix: courses.length === 1 ? "" : "s",
+              },
+            )}
+          </p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 xl:min-w-[24rem] xl:grid-cols-3">
+          <StatCard
+            label={t("content.stats.totalHoursLabel", "Catalog hours")}
+            value={new Intl.NumberFormat().format(
+              Math.round(courseStats.totalHours),
+            )}
+            hint={t(
+              "content.stats.totalHoursHint",
+              "Hours of learning available",
+            )}
+          />
+          <StatCard
+            label={t(
+              "content.stats.averageCompletionLabel",
+              "Avg. completion",
+            )}
+            value={`${courseStats.averageCompletion.toFixed(0)}%`}
+            hint={t(
+              "content.stats.averageCompletionHint",
+              "Across published courses",
+            )}
+          />
+          <StatCard
+            label={t(
+              "content.stats.activeLearnersLabel",
+              "Active learners",
+            )}
+            value={new Intl.NumberFormat().format(courseStats.activeLearners)}
+            hint={t(
+              "content.stats.activeLearnersHint",
+              "Currently enrolled",
+            )}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FiltersSection({
+  t,
+  searchTerm,
+  setSearchTerm,
+  trainingFilter,
+  setTrainingFilter,
+  hasActiveFilters,
+  trainingOptions,
+  activeTrainingOption,
+  courses,
+  filteredCount,
+}) {
+  const clearFiltersClasses =
+    "justify-center gap-2 rounded-full border border-transparent bg-surface2/70 px-4 py-2 text-sm text-secondary hover:border-border/60 hover:bg-surface2";
+
+  const activeFilterClasses =
+    "rounded-full border border-brand bg-brand px-3 py-1.5 text-xs font-medium text-white shadow-e2";
+
+  const inactiveFilterClasses =
+    "rounded-full border border-transparent bg-transparent px-3 py-1.5 text-xs font-medium text-secondary transition-all hover:border-brand/40 hover:bg-brand/5 hover:text-primary";
+
+  return (
+    <section className="rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm">
+      <div className="flex flex-col gap-6">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+          <div className="space-y-2">
+            <label
+              htmlFor="course-search"
+              className="text-xs font-medium uppercase tracking-wide text-muted"
+            >
+              {t("content.filters.searchLabel", "Search courses")}
+            </label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
+              <Input
+                id="course-search"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder={t(
+                  "content.filters.searchPlaceholder",
+                  "Search by title or description",
+                )}
+                className="h-11 rounded-2xl border-border/60 bg-surface2/70 pl-10 text-sm text-primary placeholder:text-muted"
+              />
+            </div>
+          </div>
+
+          {hasActiveFilters ? (
+            <Button
+              type="button"
+              variant="ghost"
+              className={clearFiltersClasses}
+              onClick={() => {
+                setTrainingFilter("all");
+                setSearchTerm("");
+              }}
+            >
+              <XCircle className="h-4 w-4" />
+              {t("content.filters.clear", "Clear filters")}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted">
+              {t("content.filters.trainingType", "Training type")}
+            </p>
+            <div
+              role="group"
+              aria-label={t("content.filters.trainingType", "Training type")}
+              className="mt-2 flex flex-wrap gap-2 rounded-2xl border border-border/60 bg-surface2/60 p-2"
+            >
+              {trainingOptions.map((option) => {
+                const isActive = trainingFilter === option.value;
+
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setTrainingFilter(option.value)}
+                    className={isActive ? activeFilterClasses : inactiveFilterClasses}
+                    aria-pressed={isActive}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 text-xs text-muted">
+            <Badge className="rounded-full border border-brand/30 bg-brand/10 text-brand">
+              {t("content.courseCount", "{{count}} course{{suffix}}", {
+                count: courses.length,
+                suffix: courses.length === 1 ? "" : "s",
+              })}
+            </Badge>
+            <span>
+              {t("content.resultsCount", "Showing {{count}} course{{suffix}}", {
+                count: filteredCount,
+                suffix: filteredCount === 1 ? "" : "s",
+              })}
+            </span>
+            {trainingFilter !== "all" && activeTrainingOption ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-surface2 px-3 py-1 text-xs text-secondary">
+                {t("content.filters.activeLabel", "Filtered by")}
+                {" "}
+                {activeTrainingOption.label}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CourseList({ courses, onEdit, onPreview, onAssign, emptyMessage }) {
+  if (courses.length === 0) {
+    return (
+      <div className="rounded-3xl border border-dashed border-border/60 bg-surface/60 p-12 text-center">
+        <p className="text-sm text-muted">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6">
+      {courses.map((course, index) => (
+        <CourseCard
+          key={course.id}
+          course={course}
+          index={index}
+          onEdit={onEdit}
+          onPreview={onPreview}
+          onAssign={onAssign}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StatCard({ label, value, hint }) {
+  return (
+    <div className="rounded-2xl border border-border/50 bg-surface2/80 p-4">
+      <p className="text-xs uppercase tracking-wide text-muted">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-primary">{value}</p>
+      <p className="text-xs text-muted">{hint}</p>
     </div>
   );
 }

--- a/Ascenda Padrinho att/static-audit.md
+++ b/Ascenda Padrinho att/static-audit.md
@@ -1,0 +1,80 @@
+# Frontend Static Audit (React + Vite + Tailwind)
+
+## SUMMARY
+- `ContentManagement.jsx` is free of the earlier `<motion.div>` wrappers; the two-column layout now uses semantic elements only, and `npm run build` succeeds without parser errors. 【F:src/pages/ContentManagement.jsx†L142-L237】【812fd0†L1-L9】
+- `ActiveAssignments.jsx` renders notes literally as `"{assignment.notes}"`, so intern notes never display the stored text. 【F:src/components/interns/ActiveAssignments.jsx†L181-L184】
+- `Sidebar` context defaults to a non-null object, preventing `useSidebar` from ever throwing even if consumers render outside `<SidebarProvider>`, which hides integration bugs. 【F:src/components/ui/sidebar.jsx†L4-L26】
+- Vacation approval/rejection callbacks omit `t` from their dependency arrays, so language toggles won't update notification copy until a reload. 【F:src/components/vacation/VacationRequestsPanel.jsx†L116-L149】【F:src/components/vacation/VacationRequestsPanel.jsx†L156-L201】
+
+## BLOCKERS
+_None. The reported `<motion.div>` mismatch no longer reproduces after the layout refactor; Vite build passes (`npm run build`).【F:src/pages/ContentManagement.jsx†L142-L237】【812fd0†L1-L9】_
+
+## WARNINGS
+1. **File:** `src/components/interns/ActiveAssignments.jsx` → **Lines:** 181-184  \
+   **Issue:** Notes render as the literal string `"{assignment.notes}"`.  \
+   **Impact:** Intern notes never surface to users.  \
+   **Fix:** Replace the string with a JSX interpolation so the note text renders, optionally wrapping it in typographic quotes.
+2. **File:** `src/components/ui/sidebar.jsx` → **Lines:** 4-26  \
+   **Issue:** Context default value is an object, so `useSidebar` never throws when misused.  \
+   **Impact:** Layout pieces can silently render without a provider, leaving menus stuck open/closed with no diagnostics.  \
+   **Fix:** Initialize the context with `undefined` and keep the guard so misuse throws immediately.
+3. **File:** `src/components/vacation/VacationRequestsPanel.jsx` → **Lines:** 116-201  \
+   **Issue:** `useCallback` hooks for approval/rejection omit the translation function `t`.  \
+   **Impact:** After language toggles, notifications keep stale localized strings until a reload.  \
+   **Fix:** Add `t` (and any other localized helpers) to the dependency arrays.
+
+## QUICK FIX PR PLAN
+1. **Render intern notes correctly**  \
+   _Files:_ `src/components/interns/ActiveAssignments.jsx`  \
+   _Change:_ Replace the literal `"{assignment.notes}"` with `{assignment.notes}` (optionally wrapped in smart quotes) inside the `<p>` so stored notes show up.
+2. **Harden sidebar context guardrails**  \
+   _Files:_ `src/components/ui/sidebar.jsx`  \
+   _Change:_ Initialize `SidebarContext` with `undefined`, update the guard to throw when context is `undefined`, and keep the existing provider usage.
+3. **Stabilize translation callbacks**  \
+   _Files:_ `src/components/vacation/VacationRequestsPanel.jsx`  \
+   _Change:_ Include `t` in the dependency arrays for `handleApprove` and `confirmReject` so locale changes propagate immediately.
+
+## SAMPLE PATCHES
+```diff
+--- a/src/components/interns/ActiveAssignments.jsx
++++ b/src/components/interns/ActiveAssignments.jsx
+@@
+-                {assignment.notes && (
+-                  <p className="text-xs text-muted italic mb-3 p-2 bg-surface rounded border border-border">
+-                    "{assignment.notes}"
+-                  </p>
+-                )}
++                {assignment.notes && (
++                  <p className="text-xs text-muted italic mb-3 p-2 bg-surface rounded border border-border">
++                    &ldquo;{assignment.notes}&rdquo;
++                  </p>
++                )}
+```
+```diff
+--- a/src/components/ui/sidebar.jsx
++++ b/src/components/ui/sidebar.jsx
+@@
+-const SidebarContext = React.createContext({ isOpen: false, toggle: () => {}, setOpen: () => {} });
++const SidebarContext = React.createContext(undefined);
+@@
+-  const context = React.useContext(SidebarContext);
+-  if (!context) {
++  const context = React.useContext(SidebarContext);
++  if (context === undefined) {
+     throw new Error('Sidebar components must be used within <SidebarProvider>');
+   }
+```
+```diff
+--- a/src/components/vacation/VacationRequestsPanel.jsx
++++ b/src/components/vacation/VacationRequestsPanel.jsx
+@@
+-  }, [processingId, internsById, user, loadData]);
++  }, [processingId, internsById, user, loadData, t]);
+@@
+-  }, [rejectDialog, processingId, managerNote, internsById, user, loadData]);
++  }, [rejectDialog, processingId, managerNote, internsById, user, loadData, t]);
+```
+
+## CHECKLIST TO VERIFY
+1. `npm run build` – should complete without JSX parser errors or chunk warnings beyond the existing size notice.【812fd0†L1-L9】
+


### PR DESCRIPTION
## Summary
- replace the ContentManagement page grid with a straightforward two-column flex layout that omits framer-motion wrappers
- simplify the helper sections into standard functions so their JSX trees have clear opening and closing tags
- keep the course list, filters, and summary cards intact while ensuring the page renders without motion-specific markup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5a3ffa84c832dadfb694f588be329