### PR TITLE
Move course creation to modal and validate duration

### DIFF
--- a/Ascenda Padrinho att/index.html
+++ b/Ascenda Padrinho att/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ascenda Manager Portal</title>
+    <link rel="icon" href="/favicon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/Ascenda Padrinho att/public/favicon.svg
+++ b/Ascenda Padrinho att/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff7a18" />
+      <stop offset="100%" stop-color="#af002d" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g)" />
+  <path d="M20 44V18h8.4c4.9 0 8.3 2.8 8.3 7.2 0 3-1.5 5.4-4 6.5l5.4 12.3h-6.8l-4.7-11.1h-2.2V44H20zm6.6-15h1.3c1.9 0 3.1-1 3.1-2.8s-1.2-2.7-3.1-2.7h-1.3V29z" fill="#fff" />
+</svg>

--- a/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -77,7 +76,7 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
         description: formData.description,
         category: formData.category,
         difficulty: formData.difficulty,
-        duration_hours: parseFloat(formData.duration_hours) || 0,
+        duration_hours: Math.max(0, parseFloat(formData.duration_hours) || 0),
         enrolled_count: 0,
         completion_rate: 0,
         published: true
@@ -117,15 +116,7 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
   }, [formData, file, onSuccess]);
 
   return (
-    <Card className="border-border bg-surface shadow-e1">
-      <CardHeader>
-        <CardTitle className="text-primary flex items-center gap-2">
-          <Upload className="w-5 h-5" />
-          Add New Course
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <Label htmlFor="title" className="text-secondary">Course Title *</Label>
             <Input
@@ -183,15 +174,31 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
 
             <div>
               <Label htmlFor="duration" className="text-secondary">Duration (hours)</Label>
-              <Input
-                id="duration"
-                type="number"
-                step="0.5"
-                value={formData.duration_hours}
-                onChange={(e) => setFormData({ ...formData, duration_hours: e.target.value })}
-                placeholder="5.5"
-                className="bg-surface2 border-border text-primary placeholder:text-muted"
-              />
+            <Input
+              id="duration"
+              type="number"
+              step="0.5"
+              min="0"
+              value={formData.duration_hours}
+              onChange={(e) => {
+                const value = e.target.value;
+                if (value === "") {
+                  setFormData({ ...formData, duration_hours: "" });
+                  return;
+                }
+
+                if (value === "-") {
+                  return;
+                }
+
+                const parsed = parseFloat(value);
+                if (!Number.isNaN(parsed) && parsed >= 0) {
+                  setFormData({ ...formData, duration_hours: value });
+                }
+              }}
+              placeholder="5.5"
+              className="bg-surface2 border-border text-primary placeholder:text-muted"
+            />
             </div>
           </div>
 
@@ -266,7 +273,5 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
             )}
           </Button>
         </form>
-      </CardContent>
-    </Card>
   );
 }

--- a/Ascenda Padrinho att/src/pages/ContentManagement.jsx
+++ b/Ascenda Padrinho att/src/pages/ContentManagement.jsx
@@ -6,6 +6,14 @@ import CourseCard from "../components/content/CourseCard";
 import CourseEditModal from "../components/content/CourseEditModal";
 import PreviewDrawer from "../components/media/PreviewDrawer";
 import AssignCourseModal from "../components/courses/AssignCourseModal";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Upload } from "lucide-react";
 
 export default function ContentManagement() {
   const [courses, setCourses] = useState([]);
@@ -15,6 +23,7 @@ export default function ContentManagement() {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [assigningCourse, setAssigningCourse] = useState(null);
   const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
   const loadCourses = useCallback(async () => {
     const data = await Course.list('-created_date');
@@ -28,6 +37,7 @@ export default function ContentManagement() {
   const handleCourseCreate = useCallback(async (courseData) => {
     await Course.create(courseData);
     loadCourses();
+    setIsCreateModalOpen(false);
   }, [loadCourses]);
 
   const handleEdit = useCallback((course) => {
@@ -72,39 +82,38 @@ export default function ContentManagement() {
           <p className="text-muted">Create and manage training materials for your team</p>
         </motion.div>
 
-        <div className="grid lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-1">
-            <CourseUploadForm 
-              onSuccess={handleCourseCreate}
-              onPreview={handleFormPreview}
-            />
-          </div>
-
-          <div className="lg:col-span-2 space-y-6">
-            <div className="flex items-center justify-between">
+        <div className="space-y-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
               <h2 className="text-2xl font-bold text-primary">Course Library</h2>
               <span className="text-sm text-muted">{courses.length} courses</span>
             </div>
-
-            <div className="grid gap-6">
-              {courses.map((course, index) => (
-                <CourseCard 
-                  key={course.id} 
-                  course={course} 
-                  index={index}
-                  onEdit={handleEdit}
-                  onPreview={handlePreview}
-                  onAssign={handleAssign}
-                />
-              ))}
-            </div>
-
-            {courses.length === 0 && (
-              <div className="text-center py-12 bg-surface2 border border-border rounded-xl">
-                <p className="text-muted">No courses yet. Create your first one!</p>
-              </div>
-            )}
+            <Button
+              onClick={() => setIsCreateModalOpen(true)}
+              className="bg-brand hover:bg-brand/90 text-white"
+            >
+              Add New Course
+            </Button>
           </div>
+
+          <div className="grid gap-6">
+            {courses.map((course, index) => (
+              <CourseCard
+                key={course.id}
+                course={course}
+                index={index}
+                onEdit={handleEdit}
+                onPreview={handlePreview}
+                onAssign={handleAssign}
+              />
+            ))}
+          </div>
+
+          {courses.length === 0 && (
+            <div className="text-center py-12 bg-surface2 border border-border rounded-xl">
+              <p className="text-muted">No courses yet. Create your first one!</p>
+            </div>
+          )}
         </div>
 
         <CourseEditModal
@@ -126,6 +135,23 @@ export default function ContentManagement() {
           onClose={() => setIsAssignModalOpen(false)}
           onSuccess={handleAssignSuccess}
         />
+
+        <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>
+          <DialogContent className="max-w-2xl bg-surface border-border text-primary max-h-[90vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2 text-primary">
+                <Upload className="w-5 h-5" />
+                Add New Course
+              </DialogTitle>
+            </DialogHeader>
+            <div className="p-6 pt-4">
+              <CourseUploadForm
+                onSuccess={handleCourseCreate}
+                onPreview={handleFormPreview}
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a gradient favicon for the Ascenda Padrinho att project
- reference the new favicon from the HTML document head
- open course creation from a modal instead of an always-visible card
- block negative course durations when saving new content

## Testing
- npm run build *(fails: vite is unavailable before dependencies can be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68df274de978832db2a866c717434bd5