### PR TITLE
Improve course upload form selects and input styling

### DIFF
--- a/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
@@ -128,47 +128,49 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
   }, [formData, file, onSuccess]);
 
   return (
-    <Card className="border-border bg-surface shadow-e1">
-      <CardHeader>
-        <CardTitle className="text-primary flex items-center gap-2">
-          <Upload className="w-5 h-5" />
+    <Card className="overflow-visible border-border/60 bg-surface shadow-e1">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-xl font-semibold text-primary">
+          <Upload className="h-5 w-5" />
           {t("content.addCourse")}
         </CardTitle>
       </CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <Label htmlFor="title" className="text-secondary">{t("courseForm.titleLabel")}</Label>
+      <CardContent className="pt-0">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="title">{t("courseForm.titleLabel")}</Label>
             <Input
               id="title"
               value={formData.title}
               onChange={(e) => setFormData({ ...formData, title: e.target.value })}
               placeholder={t("common.placeholders.courseTitleExample")}
               required
-              className="bg-surface2 border-border text-primary placeholder:text-muted"
             />
           </div>
 
-          <div>
-            <Label htmlFor="description" className="text-secondary">{t("courseForm.descriptionLabel")}</Label>
+          <div className="space-y-2">
+            <Label htmlFor="description">{t("courseForm.descriptionLabel")}</Label>
             <Textarea
               id="description"
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
               placeholder={t("common.placeholders.courseDescription")}
               required
-              className="bg-surface2 border-border text-primary placeholder:text-muted h-24"
+              className="min-h-[6rem]"
             />
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div>
-              <Label htmlFor="category" className="text-secondary">{t("courseForm.categoryLabel")}</Label>
-              <Select value={formData.category} onValueChange={(value) => setFormData({ ...formData, category: value })}>
-                <SelectTrigger className="bg-surface2 border-border text-primary">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="category">{t("courseForm.categoryLabel")}</Label>
+              <Select
+                value={formData.category}
+                onValueChange={(value) => setFormData({ ...formData, category: value })}
+              >
+                <SelectTrigger id="category">
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent className="bg-surface border-border">
+                <SelectContent position="popper" sideOffset={6}>
                   <SelectItem value="Technical">{t("courseForm.categories.technical")}</SelectItem>
                   <SelectItem value="Leadership">{t("courseForm.categories.leadership")}</SelectItem>
                   <SelectItem value="Communication">{t("courseForm.categories.communication")}</SelectItem>
@@ -178,13 +180,16 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
               </Select>
             </div>
 
-            <div>
-              <Label htmlFor="difficulty" className="text-secondary">{t("courseForm.difficultyLabel")}</Label>
-              <Select value={formData.difficulty} onValueChange={(value) => setFormData({ ...formData, difficulty: value })}>
-                <SelectTrigger className="bg-surface2 border-border text-primary">
+            <div className="space-y-2">
+              <Label htmlFor="difficulty">{t("courseForm.difficultyLabel")}</Label>
+              <Select
+                value={formData.difficulty}
+                onValueChange={(value) => setFormData({ ...formData, difficulty: value })}
+              >
+                <SelectTrigger id="difficulty">
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent className="bg-surface border-border">
+                <SelectContent position="popper" sideOffset={6}>
                   <SelectItem value="Beginner">{t("courseForm.difficulties.beginner")}</SelectItem>
                   <SelectItem value="Intermediate">{t("courseForm.difficulties.intermediate")}</SelectItem>
                   <SelectItem value="Advanced">{t("courseForm.difficulties.advanced")}</SelectItem>
@@ -192,16 +197,16 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
               </Select>
             </div>
 
-            <div>
-              <Label htmlFor="training-type" className="text-secondary">{t("courseForm.trainingTypeLabel")}</Label>
+            <div className="space-y-2">
+              <Label htmlFor="training-type">{t("courseForm.trainingTypeLabel")}</Label>
               <Select
                 value={formData.training_type}
                 onValueChange={(value) => setFormData({ ...formData, training_type: value })}
               >
-                <SelectTrigger className="bg-surface2 border-border text-primary">
+                <SelectTrigger id="training-type">
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent className="bg-surface border-border">
+                <SelectContent position="popper" sideOffset={6}>
                   {trainingOptions.map((option) => (
                     <SelectItem key={option.value} value={option.value}>
                       {option.label}
@@ -211,31 +216,31 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
               </Select>
             </div>
 
-            <div>
-              <Label htmlFor="duration" className="text-secondary">{t("courseForm.durationLabel")}</Label>
+            <div className="space-y-2">
+              <Label htmlFor="duration">{t("courseForm.durationLabel")}</Label>
               <Input
                 id="duration"
                 type="number"
-                step="0.5"
+                min={0}
+                step={0.5}
+                inputMode="decimal"
                 value={formData.duration_hours}
                 onChange={(e) => setFormData({ ...formData, duration_hours: e.target.value })}
                 placeholder="5.5"
-                className="bg-surface2 border-border text-primary placeholder:text-muted"
               />
             </div>
           </div>
 
-          <div>
-            <Label htmlFor="youtube" className="text-secondary flex items-center gap-2">
-              <Youtube className="w-4 h-4 text-error" />
-              {t("courseForm.youtubeLabel")}
+          <div className="space-y-2">
+            <Label htmlFor="youtube" className="flex items-center gap-2">
+              <Youtube className="h-4 w-4 text-error" />
+              <span>{t("courseForm.youtubeLabel")}</span>
             </Label>
             <Input
               id="youtube"
               value={formData.youtube_url}
               onChange={(e) => setFormData({ ...formData, youtube_url: e.target.value })}
               placeholder={t("common.placeholders.youtubeUrl")}
-              className="bg-surface2 border-border text-primary placeholder:text-muted"
             />
             <YouTubePreview
               url={formData.youtube_url}
@@ -243,21 +248,19 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
             />
           </div>
 
-          <div>
-            <Label htmlFor="file" className="text-secondary">{t("courseForm.materialsLabel")}</Label>
-            <div className="mt-2">
-              <label className="flex items-center justify-center w-full h-32 border-2 border-dashed border-border rounded-xl cursor-pointer hover:border-brand transition-colors bg-surface2">
-                <div className="text-center">
-                  <Upload className="w-8 h-8 mx-auto mb-2 text-brand" />
-                  <span className="text-sm text-muted">
-                    {file ? file.name : t("common.placeholders.uploadPrompt")}
+          <div className="space-y-2">
+            <Label htmlFor="file">{t("courseForm.materialsLabel")}</Label>
+            <div className="rounded-2xl border-2 border-dashed border-border/60 bg-surface2/70 p-4">
+              <label className="flex h-28 w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-transparent bg-transparent text-center transition-colors hover:border-brand/60">
+                <Upload className="h-8 w-8 text-brand" />
+                <span className="text-sm text-muted">
+                  {file ? file.name : t("common.placeholders.uploadPrompt")}
+                </span>
+                {file && (
+                  <span className="text-xs text-muted">
+                    {(file.size / 1024 / 1024).toFixed(2)} MB
                   </span>
-                  {file && (
-                    <span className="text-xs text-muted block mt-1">
-                      {(file.size / 1024 / 1024).toFixed(2)} MB
-                    </span>
-                  )}
-                </div>
+                )}
                 <input
                   id="file"
                   type="file"

--- a/Ascenda Padrinho att/src/components/ui/input.jsx
+++ b/Ascenda Padrinho att/src/components/ui/input.jsx
@@ -6,7 +6,10 @@ export const Input = React.forwardRef(function Input({ className, type = 'text',
     <input
       ref={ref}
       type={type}
-      className={cn('flex h-10 w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-primary placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:cursor-not-allowed disabled:opacity-50', className)}
+      className={cn(
+        'flex h-10 w-full rounded-2xl border border-border/60 bg-surface2/70 px-4 text-sm text-primary placeholder:text-muted shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
       {...props}
     />
   );

--- a/Ascenda Padrinho att/src/components/ui/label.jsx
+++ b/Ascenda Padrinho att/src/components/ui/label.jsx
@@ -5,7 +5,7 @@ export const Label = React.forwardRef(function Label({ className, ...props }, re
   return (
     <label
       ref={ref}
-      className={cn('text-sm font-medium text-secondary', className)}
+      className={cn('text-xs font-medium uppercase tracking-wide text-muted', className)}
       {...props}
     />
   );

--- a/Ascenda Padrinho att/src/components/ui/select.jsx
+++ b/Ascenda Padrinho att/src/components/ui/select.jsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import { cn } from '@/utils';
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { ChevronDown, Check } from "lucide-react";
+import { cn } from "@/utils";
 
 const SelectContext = React.createContext(null);
+let selectIdCounter = 0;
+const selectRegistry = new Map();
 
 function useSelectContext() {
   const context = React.useContext(SelectContext);
   if (!context) {
-    throw new Error('Select components must be used within <Select>');
+    throw new Error("Select components must be used within <Select>");
   }
   return context;
 }
@@ -14,28 +18,75 @@ function useSelectContext() {
 const getTextFromChildren = (children) => {
   return React.Children.toArray(children)
     .map((child) => {
-      if (typeof child === 'string') return child;
-      if (typeof child === 'number') return String(child);
+      if (typeof child === "string") return child;
+      if (typeof child === "number") return String(child);
       if (React.isValidElement(child)) {
         return getTextFromChildren(child.props.children);
       }
-      return '';
+      return "";
     })
-    .join(' ')
+    .join(" ")
     .trim();
 };
 
 export function Select({ value, defaultValue, onValueChange, children, className }) {
-  const [open, setOpen] = React.useState(false);
+  const [openState, setOpenState] = React.useState(false);
   const [internalValue, setInternalValue] = React.useState(defaultValue ?? null);
-  const [selectedLabel, setSelectedLabel] = React.useState('');
+  const [selectedLabel, setSelectedLabel] = React.useState("");
   const [options, setOptions] = React.useState({});
+  const [optionOrder, setOptionOrder] = React.useState([]);
+  const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
+  const [triggerRect, setTriggerRect] = React.useState(null);
+  const triggerRef = React.useRef(null);
+  const optionRefs = React.useRef(new Map());
 
   const isControlled = value !== undefined;
   const currentValue = isControlled ? value : internalValue;
 
+  const selectIdRef = React.useRef(null);
+  if (selectIdRef.current === null) {
+    selectIdRef.current = `select-${++selectIdCounter}`;
+  }
+
+  const close = React.useCallback(() => {
+    setOpenState(false);
+  }, []);
+
+  React.useEffect(() => {
+    selectRegistry.set(selectIdRef.current, close);
+    return () => {
+      selectRegistry.delete(selectIdRef.current);
+    };
+  }, [close]);
+
+  const setOpen = React.useCallback((nextOpen) => {
+    setOpenState((prev) => {
+      const valueToSet = typeof nextOpen === "function" ? nextOpen(prev) : nextOpen;
+      if (valueToSet) {
+        selectRegistry.forEach((closeFn, id) => {
+          if (id !== selectIdRef.current) {
+            closeFn();
+          }
+        });
+      }
+      return valueToSet;
+    });
+  }, []);
+
   const registerOption = React.useCallback((optionValue, label) => {
     setOptions((prev) => ({ ...prev, [optionValue]: label }));
+    setOptionOrder((prev) => (prev.includes(optionValue) ? prev : [...prev, optionValue]));
+  }, []);
+
+  const unregisterOption = React.useCallback((optionValue) => {
+    setOptions((prev) => {
+      if (!(optionValue in prev)) return prev;
+      const next = { ...prev };
+      delete next[optionValue];
+      return next;
+    });
+    setOptionOrder((prev) => prev.filter((value) => value !== optionValue));
+    optionRefs.current.delete(optionValue);
   }, []);
 
   React.useEffect(() => {
@@ -44,54 +95,160 @@ export function Select({ value, defaultValue, onValueChange, children, className
     }
   }, [currentValue, options]);
 
+  const updateTriggerRect = React.useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setTriggerRect({
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+      right: rect.right,
+      bottom: rect.bottom,
+    });
+  }, []);
+
   const selectValue = React.useCallback(
     (nextValue, label) => {
       if (!isControlled) {
         setInternalValue(nextValue);
       }
-      setSelectedLabel(label ?? options[nextValue] ?? '');
+      setSelectedLabel(label ?? options[nextValue] ?? "");
       onValueChange?.(nextValue);
-      setOpen(false);
+      close();
     },
-    [isControlled, onValueChange, options],
+    [close, isControlled, onValueChange, options],
   );
+
+  React.useEffect(() => {
+    if (!openState) return;
+    updateTriggerRect();
+    const handleResize = () => updateTriggerRect();
+    const handleScroll = () => updateTriggerRect();
+
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("scroll", handleScroll, true);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("scroll", handleScroll, true);
+    };
+  }, [openState, updateTriggerRect]);
+
+  React.useEffect(() => {
+    if (!openState) {
+      setHighlightedIndex(-1);
+      return;
+    }
+    const currentIndex = optionOrder.indexOf(currentValue);
+    setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
+  }, [openState, optionOrder, currentValue]);
+
+  React.useEffect(() => {
+    if (!openState || highlightedIndex < 0) return;
+    const valueAtIndex = optionOrder[highlightedIndex];
+    if (!valueAtIndex) return;
+    const node = optionRefs.current.get(valueAtIndex);
+    node?.focus();
+  }, [openState, highlightedIndex, optionOrder]);
 
   const contextValue = React.useMemo(
     () => ({
-      open,
+      open: openState,
       setOpen,
       value: currentValue,
       selectedLabel,
       registerOption,
+      unregisterOption,
       selectValue,
+      highlightedIndex,
+      setHighlightedIndex,
+      optionOrder,
+      triggerRef,
+      triggerRect,
+      updateTriggerRect,
+      optionRefs,
     }),
-    [open, currentValue, selectedLabel, registerOption, selectValue],
+    [
+      openState,
+      setOpen,
+      currentValue,
+      selectedLabel,
+      registerOption,
+      unregisterOption,
+      selectValue,
+      highlightedIndex,
+      optionOrder,
+      triggerRect,
+      updateTriggerRect,
+    ],
   );
 
   return (
     <SelectContext.Provider value={contextValue}>
-      <div className={cn('relative w-full', className)}>{children}</div>
+      <div className={cn("relative w-full", className)}>{children}</div>
     </SelectContext.Provider>
   );
 }
 
-export const SelectTrigger = React.forwardRef(function SelectTrigger({ className, children, ...props }, ref) {
-  const { open, setOpen } = useSelectContext();
+export const SelectTrigger = React.forwardRef(function SelectTrigger(
+  { className, children, onClick, onKeyDown, ...props },
+  forwardedRef,
+) {
+  const { open, setOpen, triggerRef, updateTriggerRect } = useSelectContext();
+
+  const assignRef = React.useCallback(
+    (node) => {
+      triggerRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        forwardedRef.current = node;
+      }
+    },
+    [forwardedRef, triggerRef],
+  );
+
+  const handleToggle = React.useCallback(
+    (event) => {
+      onClick?.(event);
+      updateTriggerRect();
+      setOpen((prev) => !prev);
+    },
+    [onClick, setOpen, updateTriggerRect],
+  );
+
+  const handleKeyDown = React.useCallback(
+    (event) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented) return;
+      const keysToOpen = ["Enter", " ", "ArrowDown", "ArrowUp"];
+      if (keysToOpen.includes(event.key)) {
+        event.preventDefault();
+        updateTriggerRect();
+        setOpen(true);
+      }
+    },
+    [onKeyDown, setOpen, updateTriggerRect],
+  );
 
   return (
     <button
       type="button"
-      ref={ref}
-      onClick={() => setOpen(!open)}
+      ref={assignRef}
+      data-state={open ? "open" : "closed"}
+      onClick={handleToggle}
+      onKeyDown={handleKeyDown}
       className={cn(
-        'flex w-full items-center justify-between rounded-lg border border-border bg-surface px-3 py-2 text-sm text-primary transition-colors hover:bg-surface2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand',
+        "flex h-10 w-full items-center justify-between rounded-2xl border border-border/60 bg-surface2/70 px-4 text-sm text-primary shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50 data-[state=open]:ring-2 data-[state=open]:ring-brand data-[placeholder]:text-muted",
         className,
       )}
+      aria-haspopup="listbox"
       aria-expanded={open}
       {...props}
     >
       <div className="flex flex-1 items-center gap-2 overflow-hidden">{children}</div>
-      <span className="ml-2 text-xs text-muted">▾</span>
+      <ChevronDown className="ml-2 h-4 w-4 text-muted" aria-hidden="true" />
     </button>
   );
 });
@@ -100,45 +257,190 @@ export const SelectValue = ({ placeholder, className }) => {
   const { selectedLabel } = useSelectContext();
   const hasValue = Boolean(selectedLabel);
   return (
-    <span className={cn('truncate', !hasValue && 'text-muted', className)}>
-      {hasValue ? selectedLabel : placeholder || 'Selecione'}
+    <span className={cn("truncate", !hasValue && "text-muted", className)}>
+      {hasValue ? selectedLabel : placeholder || "Select"}
     </span>
   );
 };
 
-export function SelectContent({ className, children }) {
-  const { open } = useSelectContext();
-  if (!open) return null;
+export function SelectContent({ className, children, position = "popper", sideOffset = 6, viewportClassName }) {
+  const {
+    open,
+    setOpen,
+    triggerRef,
+    triggerRect,
+    highlightedIndex,
+    setHighlightedIndex,
+    optionOrder,
+    optionRefs,
+  } = useSelectContext();
 
-  return (
-    <div className={cn('absolute z-50 mt-2 w-full overflow-hidden rounded-lg border border-border bg-surface shadow-e2', className)}>
-      <div className="max-h-60 overflow-auto py-1">{children}</div>
+  const contentRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event) => {
+      const target = event.target;
+      if (contentRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+
+    const handleKey = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+      if (event.key === "Tab") {
+        setOpen(false);
+        return;
+      }
+      if (!optionOrder.length) return;
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setHighlightedIndex((prev) => {
+          const nextIndex = prev < optionOrder.length - 1 ? prev + 1 : 0;
+          return nextIndex;
+        });
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setHighlightedIndex((prev) => {
+          const nextIndex = prev > 0 ? prev - 1 : optionOrder.length - 1;
+          return nextIndex;
+        });
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKey);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open, optionOrder, setHighlightedIndex, setOpen, triggerRef]);
+
+  if (!open || !triggerRect) return null;
+
+  const spaceBelow = window.innerHeight - triggerRect.bottom;
+  const spaceAbove = triggerRect.top;
+  const shouldOpenUpwards = position === "popper" && spaceAbove > spaceBelow && spaceBelow < 200;
+
+  const availableSpaceRaw = shouldOpenUpwards
+    ? Math.max(spaceAbove - sideOffset - 12, 0)
+    : Math.max(spaceBelow - sideOffset - 12, 0);
+  const maxViewportHeight = Math.max(window.innerHeight - 120, 220);
+  const maxAvailable = Math.min(Math.max(availableSpaceRaw, 160), maxViewportHeight);
+
+  const style = {
+    top: shouldOpenUpwards
+      ? triggerRect.top + window.scrollY - sideOffset
+      : triggerRect.bottom + window.scrollY + sideOffset,
+    left: triggerRect.left + window.scrollX,
+    maxHeight: `${maxAvailable}px`,
+    transform: shouldOpenUpwards ? "translateY(-100%)" : undefined,
+    "--trigger-width": `${triggerRect.width}px`,
+  };
+
+  const content = (
+    <div
+      ref={contentRef}
+      style={style}
+      className={cn(
+        "z-[9999] w-[var(--trigger-width)] min-w-[12rem] overflow-hidden rounded-xl border border-border/60 bg-surface shadow-e3",
+        "data-[placement=top]:origin-bottom data-[placement=bottom]:origin-top",
+        className,
+      )}
+      data-placement={shouldOpenUpwards ? "top" : "bottom"}
+      role="listbox"
+      tabIndex={-1}
+    >
+      <div className={cn("max-h-full overflow-y-auto p-1", viewportClassName)}>{children}</div>
     </div>
   );
+
+  return createPortal(content, document.body);
 }
 
 export function SelectItem({ className, value, children }) {
-  const { value: selected, selectValue, registerOption } = useSelectContext();
+  const {
+    value: selected,
+    selectValue,
+    registerOption,
+    unregisterOption,
+    optionOrder,
+    highlightedIndex,
+    optionRefs,
+    open,
+    setHighlightedIndex,
+  } = useSelectContext();
   const label = React.useMemo(() => getTextFromChildren(children), [children]);
+  const internalRef = React.useRef(null);
 
   React.useEffect(() => {
     registerOption(value, label);
-  }, [registerOption, value, label]);
+    return () => unregisterOption(value);
+  }, [label, registerOption, unregisterOption, value]);
 
+  React.useEffect(() => {
+    if (internalRef.current) {
+      optionRefs.current.set(value, internalRef.current);
+      return () => {
+        optionRefs.current.delete(value);
+      };
+    }
+  }, [optionRefs, value]);
+
+  const index = optionOrder.indexOf(value);
   const isSelected = selected === value;
+  const isHighlighted = highlightedIndex === index;
+
+  React.useEffect(() => {
+    if (isHighlighted && open) {
+      internalRef.current?.focus();
+    }
+  }, [isHighlighted, open]);
+
+  const handleMouseEnter = React.useCallback(() => {
+    if (index >= 0) {
+      setHighlightedIndex(index);
+    }
+  }, [index, setHighlightedIndex]);
+
+  const handleFocus = React.useCallback(() => {
+    if (index >= 0) {
+      setHighlightedIndex(index);
+    }
+  }, [index, setHighlightedIndex]);
 
   return (
     <button
       type="button"
+      ref={internalRef}
       onClick={() => selectValue(value, label)}
       className={cn(
-        'flex w-full items-center justify-start px-3 py-2 text-sm text-secondary hover:bg-surface2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand',
-        isSelected && 'bg-surface2 text-primary',
+        "relative flex w-full select-none items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-primary outline-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+        "hover:bg-surface2/80 focus:bg-surface2/80",
+        isSelected && "bg-surface2/80 text-primary",
+        isHighlighted && !isSelected && "bg-surface2/60",
         className,
       )}
+      onMouseEnter={handleMouseEnter}
+      onFocus={handleFocus}
+      role="option"
+      aria-selected={isSelected}
+      tabIndex={-1}
     >
-      {children}
+      <span className="pointer-events-none absolute right-3 flex h-3.5 w-3.5 items-center justify-center text-brand">
+        {isSelected && <Check className="h-3 w-3" aria-hidden="true" />}
+      </span>
+      <span className="truncate">{children}</span>
     </button>
   );
 }
 
+export const SelectSeparator = ({ className }) => (
+  <div className={cn("-mx-1 my-1 h-px bg-border/60", className)} aria-hidden="true" />
+);

--- a/Ascenda Padrinho att/src/components/ui/textarea.jsx
+++ b/Ascenda Padrinho att/src/components/ui/textarea.jsx
@@ -5,7 +5,10 @@ export const Textarea = React.forwardRef(function Textarea({ className, ...props
   return (
     <textarea
       ref={ref}
-      className={cn('flex w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-primary placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:cursor-not-allowed disabled:opacity-50', className)}
+      className={cn(
+        'flex w-full rounded-2xl border border-border/60 bg-surface2/70 px-4 py-3 text-sm text-primary placeholder:text-muted shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
       {...props}
     />
   );

--- a/Ascenda Padrinho att/src/index.css
+++ b/Ascenda Padrinho att/src/index.css
@@ -20,6 +20,16 @@
     font-family: inherit;
   }
 
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  input[type='number'] {
+    -moz-appearance: textfield;
+  }
+
   :root {
     color-scheme: light;
   }


### PR DESCRIPTION
## Summary
- restyle the course upload form to use consistent label, input, and grid spacing tokens
- replace the select implementation with a portal-based dropdown that matches trigger width and closes on outside interaction
- align duration number input and upload drop zone visuals with the new surface and border treatments while disabling browser spinners

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6abfc4b70832dacce11bb72aec180