### PR TITLE
Fix select component state management

### DIFF
--- a/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
@@ -10,7 +10,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  SelectViewport,
 } from "@/components/ui/select";
 import { UploadFile } from "@/integrations/Core";
 import { Upload, Loader2, Youtube, Eye } from "lucide-react";


### PR DESCRIPTION
## Summary
- refactor the select component to unify open state handling and avoid duplicate refs
- support controlled open state while keeping option/highlight behaviour in sync
- remove an unused SelectViewport import from the course upload form

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7b5c37df8832daea867466cbfc07f