### PR TITLE
Improve select dropdown positioning and responsiveness

### DIFF
--- a/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
@@ -10,7 +10,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  SelectViewport,
 } from "@/components/ui/select";
 import { UploadFile } from "@/integrations/Core";
 import { Upload, Loader2, Youtube, Eye } from "lucide-react";
@@ -39,9 +38,6 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
     () => allTrainingOptions.filter(option => option.value !== "all"),
     [allTrainingOptions]
   );
-  const selectContentClassName =
-    "z-[9999] rounded-xl border border-border/60 bg-surface p-0 shadow-e3 w-[var(--radix-select-trigger-width)] min-w-[12rem]";
-
   const handleFileChange = React.useCallback(async (e) => {
     const selectedFile = e.target.files[0];
     if (!selectedFile) return;


### PR DESCRIPTION
## Summary
- update the custom Select component to continuously measure the trigger, keep only one menu open, and synchronize the highlighted option
- render dropdown content in a fixed-position portal that matches the trigger width, applies collision-aware placement, and closes on outside interactions
- tidy the course upload form by removing an unused select content style helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7b5c37df8832daea867466cbfc07f