### PR TITLE
Stabilize Select IDs and registry handling

### DIFF
--- a/Ascenda Padrinho att/src/components/content/CourseEditModal.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseEditModal.jsx
@@ -120,7 +120,11 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
           <div className="grid grid-cols-3 gap-4 lg:grid-cols-4">
             <div>
               <Label htmlFor="edit-category" className="text-secondary">{t("courseForm.categoryLabel")}</Label>
-              <Select value={formData.category} onValueChange={(value) => setFormData({ ...formData, category: value })}>
+              <Select
+                id="edit-category"
+                value={formData.category}
+                onValueChange={(value) => setFormData({ ...formData, category: value })}
+              >
                 <SelectTrigger className="bg-surface2 border-border text-primary">
                   <SelectValue />
                 </SelectTrigger>
@@ -136,7 +140,11 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
 
             <div>
               <Label htmlFor="edit-difficulty" className="text-secondary">{t("courseForm.difficultyLabel")}</Label>
-              <Select value={formData.difficulty} onValueChange={(value) => setFormData({ ...formData, difficulty: value })}>
+              <Select
+                id="edit-difficulty"
+                value={formData.difficulty}
+                onValueChange={(value) => setFormData({ ...formData, difficulty: value })}
+              >
                 <SelectTrigger className="bg-surface2 border-border text-primary">
                   <SelectValue />
                 </SelectTrigger>
@@ -151,6 +159,7 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
             <div>
               <Label htmlFor="edit-training-type" className="text-secondary">{t("courseForm.trainingTypeLabel")}</Label>
               <Select
+                id="edit-training-type"
                 value={formData.training_type}
                 onValueChange={(value) => setFormData({ ...formData, training_type: value })}
               >

--- a/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
@@ -10,7 +10,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  SelectViewport,
 } from "@/components/ui/select";
 import { UploadFile } from "@/integrations/Core";
 import { Upload, Loader2, Youtube, Eye } from "lucide-react";
@@ -39,9 +38,6 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
     () => allTrainingOptions.filter(option => option.value !== "all"),
     [allTrainingOptions]
   );
-  const selectContentClassName =
-    "z-[9999] rounded-xl border border-border/60 bg-surface p-0 shadow-e3 w-[var(--radix-select-trigger-width)] min-w-[12rem]";
-
   const handleFileChange = React.useCallback(async (e) => {
     const selectedFile = e.target.files[0];
     if (!selectedFile) return;
@@ -167,10 +163,11 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
             <div className="space-y-2">
               <Label htmlFor="category">{t("courseForm.categoryLabel")}</Label>
               <Select
+                id="category"
                 value={formData.category}
                 onValueChange={(value) => setFormData({ ...formData, category: value })}
               >
-                <SelectTrigger id="category">
+                <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent position="popper" sideOffset={6}>
@@ -186,10 +183,11 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
             <div className="space-y-2">
               <Label htmlFor="difficulty">{t("courseForm.difficultyLabel")}</Label>
               <Select
+                id="difficulty"
                 value={formData.difficulty}
                 onValueChange={(value) => setFormData({ ...formData, difficulty: value })}
               >
-                <SelectTrigger id="difficulty">
+                <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent position="popper" sideOffset={6}>
@@ -203,10 +201,11 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
             <div className="space-y-2">
               <Label htmlFor="training-type">{t("courseForm.trainingTypeLabel")}</Label>
               <Select
+                id="training-type"
                 value={formData.training_type}
                 onValueChange={(value) => setFormData({ ...formData, training_type: value })}
               >
-                <SelectTrigger id="training-type">
+                <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent position="popper" sideOffset={6}>

--- a/Ascenda Padrinho att/src/components/ui/select.jsx
+++ b/Ascenda Padrinho att/src/components/ui/select.jsx
@@ -3,8 +3,9 @@ import { createPortal } from "react-dom";
 import { ChevronDown, Check } from "lucide-react";
 import { cn } from "@/utils";
 
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
+
 const SelectContext = React.createContext(null);
-let selectIdCounter = 0;
 const selectRegistry = new Map();
 
 function useSelectContext() {
@@ -29,8 +30,18 @@ const getTextFromChildren = (children) => {
     .trim();
 };
 
-export function Select({ value, defaultValue, onValueChange, children, className }) {
-  const [openState, setOpenState] = React.useState(false);
+export function Select({
+  id,
+  value,
+  defaultValue,
+  onValueChange,
+  children,
+  className,
+  open: openProp,
+  defaultOpen = false,
+  onOpenChange,
+}) {
+  const [openState, setOpenState] = React.useState(defaultOpen);
   const [internalValue, setInternalValue] = React.useState(defaultValue ?? null);
   const [selectedLabel, setSelectedLabel] = React.useState("");
   const [options, setOptions] = React.useState({});
@@ -42,13 +53,42 @@ export function Select({ value, defaultValue, onValueChange, children, className
 
   const isControlled = value !== undefined;
   const currentValue = isControlled ? value : internalValue;
+
   const isOpenControlled = openProp !== undefined;
   const open = isOpenControlled ? openProp : openState;
 
-  const selectIdRef = React.useRef(null);
-  if (selectIdRef.current === null) {
-    selectIdRef.current = `select-${++selectIdCounter}`;
-  }
+  const reactId = React.useId();
+  const selectId = React.useMemo(() => {
+    if (id) return id;
+    const sanitized = reactId.replace(/:/g, "");
+    return `select-${sanitized}`;
+  }, [id, reactId]);
+
+  const updateTriggerRect = React.useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setTriggerRect({
+      top: rect.top,
+      left: rect.left,
+      bottom: rect.bottom,
+      right: rect.right,
+      width: rect.width,
+      height: rect.height,
+    });
+  }, []);
+
+  useIsomorphicLayoutEffect(() => {
+    updateTriggerRect();
+  }, [updateTriggerRect]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (typeof ResizeObserver === "undefined" || !triggerRef.current) {
+      return undefined;
+    }
+    const observer = new ResizeObserver(() => updateTriggerRect());
+    observer.observe(triggerRef.current);
+    return () => observer.disconnect();
+  }, [updateTriggerRect]);
 
   const close = React.useCallback(() => {
     if (!isOpenControlled) {
@@ -58,56 +98,29 @@ export function Select({ value, defaultValue, onValueChange, children, className
   }, [isOpenControlled, onOpenChange]);
 
   React.useEffect(() => {
-    selectRegistry.set(selectIdRef.current, close);
+    selectRegistry.set(selectId, close);
     return () => {
-      selectRegistry.delete(selectIdRef.current);
+      selectRegistry.delete(selectId);
     };
-  }, [close]);
+  }, [close, selectId]);
 
-  const setOpen = React.useCallback((nextOpen) => {
-    const resolve = typeof nextOpen === "function" ? nextOpen(open) : nextOpen;
-    if (resolve) {
-      selectRegistry.forEach((closeFn, id) => {
-        if (id !== selectIdRef.current) {
-          closeFn();
-        }
-      });
-    }
-    if (!isOpenControlled) {
-      setOpenState(resolve);
-    }
-    onOpenChange?.(resolve);
-  }, [isOpenControlled, onOpenChange, open]);
-
-  const selectIdRef = React.useRef(null);
-  if (selectIdRef.current === null) {
-    selectIdRef.current = `select-${++selectIdCounter}`;
-  }
-
-  const close = React.useCallback(() => {
-    setOpenState(false);
-  }, []);
-
-  React.useEffect(() => {
-    selectRegistry.set(selectIdRef.current, close);
-    return () => {
-      selectRegistry.delete(selectIdRef.current);
-    };
-  }, [close]);
-
-  const setOpen = React.useCallback((nextOpen) => {
-    setOpenState((prev) => {
-      const valueToSet = typeof nextOpen === "function" ? nextOpen(prev) : nextOpen;
-      if (valueToSet) {
+  const setOpen = React.useCallback(
+    (nextOpen) => {
+      const resolved = typeof nextOpen === "function" ? nextOpen(open) : nextOpen;
+      if (resolved && selectId) {
         selectRegistry.forEach((closeFn, id) => {
-          if (id !== selectIdRef.current) {
+          if (id !== selectId) {
             closeFn();
           }
         });
       }
-      return valueToSet;
-    });
-  }, []);
+      if (!isOpenControlled) {
+        setOpenState(resolved);
+      }
+      onOpenChange?.(resolved);
+    },
+    [isOpenControlled, onOpenChange, open, selectId],
+  );
 
   const registerOption = React.useCallback((optionValue, label) => {
     setOptions((prev) => ({ ...prev, [optionValue]: label }));
@@ -131,19 +144,6 @@ export function Select({ value, defaultValue, onValueChange, children, className
     }
   }, [currentValue, options]);
 
-  const updateTriggerRect = React.useCallback(() => {
-    if (!triggerRef.current) return;
-    const rect = triggerRef.current.getBoundingClientRect();
-    setTriggerRect({
-      top: rect.top,
-      left: rect.left,
-      width: rect.width,
-      height: rect.height,
-      right: rect.right,
-      bottom: rect.bottom,
-    });
-  }, []);
-
   const selectValue = React.useCallback(
     (nextValue, label) => {
       if (!isControlled) {
@@ -157,8 +157,9 @@ export function Select({ value, defaultValue, onValueChange, children, className
   );
 
   React.useEffect(() => {
-    if (!openState) return;
+    if (!open) return;
     updateTriggerRect();
+
     const handleResize = () => updateTriggerRect();
     const handleScroll = () => updateTriggerRect();
 
@@ -169,28 +170,29 @@ export function Select({ value, defaultValue, onValueChange, children, className
       window.removeEventListener("resize", handleResize);
       window.removeEventListener("scroll", handleScroll, true);
     };
-  }, [openState, updateTriggerRect]);
+  }, [open, updateTriggerRect]);
 
   React.useEffect(() => {
-    if (!openState) {
+    if (!open) {
       setHighlightedIndex(-1);
       return;
     }
     const currentIndex = optionOrder.indexOf(currentValue);
     setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
-  }, [openState, optionOrder, currentValue]);
+  }, [open, optionOrder, currentValue]);
 
   React.useEffect(() => {
-    if (!openState || highlightedIndex < 0) return;
+    if (!open || highlightedIndex < 0) return;
     const valueAtIndex = optionOrder[highlightedIndex];
     if (!valueAtIndex) return;
     const node = optionRefs.current.get(valueAtIndex);
     node?.focus();
-  }, [openState, highlightedIndex, optionOrder]);
+  }, [open, highlightedIndex, optionOrder]);
 
   const contextValue = React.useMemo(
     () => ({
-      open: openState,
+      selectId,
+      open,
       setOpen,
       value: currentValue,
       selectedLabel,
@@ -206,7 +208,8 @@ export function Select({ value, defaultValue, onValueChange, children, className
       optionRefs,
     }),
     [
-      openState,
+      selectId,
+      open,
       setOpen,
       currentValue,
       selectedLabel,
@@ -228,10 +231,10 @@ export function Select({ value, defaultValue, onValueChange, children, className
 }
 
 export const SelectTrigger = React.forwardRef(function SelectTrigger(
-  { className, children, onClick, onKeyDown, ...props },
+  { className, children, onClick, onKeyDown, id: _ignoredId, ...props },
   forwardedRef,
 ) {
-  const { open, setOpen, triggerRef, updateTriggerRect } = useSelectContext();
+  const { open, setOpen, triggerRef, updateTriggerRect, selectId } = useSelectContext();
 
   const assignRef = React.useCallback(
     (node) => {
@@ -241,13 +244,17 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
       } else if (forwardedRef) {
         forwardedRef.current = node;
       }
+      if (node) {
+        updateTriggerRect();
+      }
     },
-    [forwardedRef, triggerRef],
+    [forwardedRef, triggerRef, updateTriggerRect],
   );
 
   const handleToggle = React.useCallback(
     (event) => {
       onClick?.(event);
+      if (event.defaultPrevented) return;
       updateTriggerRect();
       setOpen((prev) => !prev);
     },
@@ -272,6 +279,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
     <button
       type="button"
       ref={assignRef}
+      id={selectId}
       data-state={open ? "open" : "closed"}
       onClick={handleToggle}
       onKeyDown={handleKeyDown}
@@ -283,8 +291,11 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
       aria-expanded={open}
       {...props}
     >
-      <div className="flex flex-1 items-center gap-2 overflow-hidden">{children}</div>
-      <ChevronDown className="ml-2 h-4 w-4 text-muted" aria-hidden="true" />
+      <div className="flex flex-1 items-center gap-2 overflow-hidden text-left">{children}</div>
+      <ChevronDown
+        className={cn("ml-2 h-4 w-4 text-muted transition-transform duration-200", open && "rotate-180")}
+        aria-hidden="true"
+      />
     </button>
   );
 });
@@ -301,6 +312,7 @@ export const SelectValue = ({ placeholder, className }) => {
 
 export function SelectContent({ className, children, position = "popper", sideOffset = 6, viewportClassName }) {
   const {
+    selectId,
     open,
     setOpen,
     triggerRef,
@@ -308,7 +320,6 @@ export function SelectContent({ className, children, position = "popper", sideOf
     highlightedIndex,
     setHighlightedIndex,
     optionOrder,
-    optionRefs,
   } = useSelectContext();
 
   const contentRef = React.useRef(null);
@@ -371,13 +382,12 @@ export function SelectContent({ className, children, position = "popper", sideOf
   const maxAvailable = Math.min(Math.max(availableSpaceRaw, 160), maxViewportHeight);
 
   const style = {
-    top: shouldOpenUpwards
-      ? triggerRect.top + window.scrollY - sideOffset
-      : triggerRect.bottom + window.scrollY + sideOffset,
-    left: triggerRect.left + window.scrollX,
+    position: "fixed",
+    top: shouldOpenUpwards ? triggerRect.top - sideOffset : triggerRect.bottom + sideOffset,
+    left: triggerRect.left,
+    width: `${triggerRect.width}px`,
     maxHeight: `${maxAvailable}px`,
     transform: shouldOpenUpwards ? "translateY(-100%)" : undefined,
-    "--trigger-width": `${triggerRect.width}px`,
   };
 
   const content = (
@@ -385,12 +395,13 @@ export function SelectContent({ className, children, position = "popper", sideOf
       ref={contentRef}
       style={style}
       className={cn(
-        "z-[9999] w-[var(--trigger-width)] min-w-[12rem] overflow-hidden rounded-xl border border-border/60 bg-surface shadow-e3",
+        "z-[9999] overflow-hidden rounded-xl border border-border/60 bg-surface shadow-e3",
         "data-[placement=top]:origin-bottom data-[placement=bottom]:origin-top",
         className,
       )}
       data-placement={shouldOpenUpwards ? "top" : "bottom"}
       role="listbox"
+      aria-labelledby={selectId}
       tabIndex={-1}
     >
       <div className={cn("max-h-full overflow-y-auto p-1", viewportClassName)}>{children}</div>


### PR DESCRIPTION
## Summary
- generate a stable selectId per instance and use it for registry bookkeeping, trigger labeling, and listbox aria attributes
- keep the single-open registry logic on the defined selectId instead of undeclared variables
- pass the select ids from course upload and edit forms so their labels remain connected to the triggers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7b5c37df8832daea867466cbfc07f