### PR TITLE
Fix select value persistence in content forms

### DIFF
--- a/Ascenda Padrinho att/src/components/content/CourseEditModal.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseEditModal.jsx
@@ -34,6 +34,33 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
     () => allTrainingOptions.filter(option => option.value !== "all"),
     [allTrainingOptions]
   );
+  const categoryOptions = useMemo(
+    () => [
+      { value: "Technical", label: t("courseForm.categories.technical") },
+      { value: "Leadership", label: t("courseForm.categories.leadership") },
+      { value: "Communication", label: t("courseForm.categories.communication") },
+      { value: "Design", label: t("courseForm.categories.design") },
+      { value: "Business", label: t("courseForm.categories.business") },
+    ],
+    [t],
+  );
+  const difficultyOptions = useMemo(
+    () => [
+      { value: "Beginner", label: t("courseForm.difficulties.beginner") },
+      { value: "Intermediate", label: t("courseForm.difficulties.intermediate") },
+      { value: "Advanced", label: t("courseForm.difficulties.advanced") },
+    ],
+    [t],
+  );
+  const selectedCategoryLabel = useMemo(() => {
+    return categoryOptions.find((option) => option.value === formData.category)?.label ?? "";
+  }, [categoryOptions, formData.category]);
+  const selectedDifficultyLabel = useMemo(() => {
+    return difficultyOptions.find((option) => option.value === formData.difficulty)?.label ?? "";
+  }, [difficultyOptions, formData.difficulty]);
+  const selectedTrainingLabel = useMemo(() => {
+    return trainingOptions.find((option) => option.value === formData.training_type)?.label ?? "";
+  }, [formData.training_type, trainingOptions]);
 
   useEffect(() => {
     if (course) {
@@ -120,30 +147,44 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
           <div className="grid grid-cols-3 gap-4 lg:grid-cols-4">
             <div>
               <Label htmlFor="edit-category" className="text-secondary">{t("courseForm.categoryLabel")}</Label>
-              <Select value={formData.category} onValueChange={(value) => setFormData({ ...formData, category: value })}>
+              <Select
+                id="edit-category"
+                value={formData.category}
+                onValueChange={(value) => setFormData({ ...formData, category: value })}
+              >
                 <SelectTrigger className="bg-surface2 border-border text-primary">
-                  <SelectValue />
+                  <SelectValue>
+                    {selectedCategoryLabel}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent className="bg-surface border-border">
-                  <SelectItem value="Technical">{t("courseForm.categories.technical")}</SelectItem>
-                  <SelectItem value="Leadership">{t("courseForm.categories.leadership")}</SelectItem>
-                  <SelectItem value="Communication">{t("courseForm.categories.communication")}</SelectItem>
-                  <SelectItem value="Design">{t("courseForm.categories.design")}</SelectItem>
-                  <SelectItem value="Business">{t("courseForm.categories.business")}</SelectItem>
+                  {categoryOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
 
             <div>
               <Label htmlFor="edit-difficulty" className="text-secondary">{t("courseForm.difficultyLabel")}</Label>
-              <Select value={formData.difficulty} onValueChange={(value) => setFormData({ ...formData, difficulty: value })}>
+              <Select
+                id="edit-difficulty"
+                value={formData.difficulty}
+                onValueChange={(value) => setFormData({ ...formData, difficulty: value })}
+              >
                 <SelectTrigger className="bg-surface2 border-border text-primary">
-                  <SelectValue />
+                  <SelectValue>
+                    {selectedDifficultyLabel}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent className="bg-surface border-border">
-                  <SelectItem value="Beginner">{t("courseForm.difficulties.beginner")}</SelectItem>
-                  <SelectItem value="Intermediate">{t("courseForm.difficulties.intermediate")}</SelectItem>
-                  <SelectItem value="Advanced">{t("courseForm.difficulties.advanced")}</SelectItem>
+                  {difficultyOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
@@ -151,11 +192,14 @@ export default function CourseEditModal({ course, isOpen, onClose, onSave }) {
             <div>
               <Label htmlFor="edit-training-type" className="text-secondary">{t("courseForm.trainingTypeLabel")}</Label>
               <Select
+                id="edit-training-type"
                 value={formData.training_type}
                 onValueChange={(value) => setFormData({ ...formData, training_type: value })}
               >
                 <SelectTrigger className="bg-surface2 border-border text-primary">
-                  <SelectValue />
+                  <SelectValue>
+                    {selectedTrainingLabel}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent className="bg-surface border-border">
                   {trainingOptions.map((option) => (

--- a/Ascenda Padrinho att/src/components/ui/select.jsx
+++ b/Ascenda Padrinho att/src/components/ui/select.jsx
@@ -3,9 +3,58 @@ import { createPortal } from "react-dom";
 import { ChevronDown, Check } from "lucide-react";
 import { cn } from "@/utils";
 
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
+
 const SelectContext = React.createContext(null);
-let selectIdCounter = 0;
 const selectRegistry = new Map();
+
+function useTriggerMeasurements(triggerRef, isListening) {
+  const [triggerRect, setTriggerRect] = React.useState(null);
+
+  const measureTriggerRect = React.useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setTriggerRect({
+      top: rect.top,
+      left: rect.left,
+      bottom: rect.bottom,
+      right: rect.right,
+      width: rect.width,
+      height: rect.height,
+    });
+  }, [triggerRef]);
+
+  useIsomorphicLayoutEffect(() => {
+    measureTriggerRect();
+  }, [measureTriggerRect]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (typeof ResizeObserver === "undefined" || !triggerRef.current) {
+      return undefined;
+    }
+    const observer = new ResizeObserver(() => measureTriggerRect());
+    observer.observe(triggerRef.current);
+    return () => observer.disconnect();
+  }, [measureTriggerRect, triggerRef]);
+
+  React.useEffect(() => {
+    if (!isListening) return undefined;
+    measureTriggerRect();
+
+    const handleResize = () => measureTriggerRect();
+    const handleScroll = () => measureTriggerRect();
+
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("scroll", handleScroll, true);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("scroll", handleScroll, true);
+    };
+  }, [isListening, measureTriggerRect]);
+
+  return { triggerRect, measureTriggerRect };
+}
 
 function useSelectContext() {
   const context = React.useContext(SelectContext);
@@ -29,26 +78,39 @@ const getTextFromChildren = (children) => {
     .trim();
 };
 
-export function Select({ value, defaultValue, onValueChange, children, className }) {
-  const [openState, setOpenState] = React.useState(false);
+export function Select({
+  id,
+  value,
+  defaultValue,
+  onValueChange,
+  children,
+  className,
+  open: openProp,
+  defaultOpen = false,
+  onOpenChange,
+}) {
+  const [openState, setOpenState] = React.useState(defaultOpen);
   const [internalValue, setInternalValue] = React.useState(defaultValue ?? null);
   const [selectedLabel, setSelectedLabel] = React.useState("");
   const [options, setOptions] = React.useState({});
   const [optionOrder, setOptionOrder] = React.useState([]);
   const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
-  const [triggerRect, setTriggerRect] = React.useState(null);
   const triggerRef = React.useRef(null);
   const optionRefs = React.useRef(new Map());
 
   const isControlled = value !== undefined;
   const currentValue = isControlled ? value : internalValue;
+
   const isOpenControlled = openProp !== undefined;
   const open = isOpenControlled ? openProp : openState;
+  const { triggerRect, measureTriggerRect } = useTriggerMeasurements(triggerRef, open);
 
-  const selectIdRef = React.useRef(null);
-  if (selectIdRef.current === null) {
-    selectIdRef.current = `select-${++selectIdCounter}`;
-  }
+  const reactId = React.useId();
+  const selectId = React.useMemo(() => {
+    if (id) return id;
+    const sanitized = reactId.replace(/:/g, "");
+    return `select-${sanitized}`;
+  }, [id, reactId]);
 
   const close = React.useCallback(() => {
     if (!isOpenControlled) {
@@ -58,56 +120,29 @@ export function Select({ value, defaultValue, onValueChange, children, className
   }, [isOpenControlled, onOpenChange]);
 
   React.useEffect(() => {
-    selectRegistry.set(selectIdRef.current, close);
+    selectRegistry.set(selectId, close);
     return () => {
-      selectRegistry.delete(selectIdRef.current);
+      selectRegistry.delete(selectId);
     };
-  }, [close]);
+  }, [close, selectId]);
 
-  const setOpen = React.useCallback((nextOpen) => {
-    const resolve = typeof nextOpen === "function" ? nextOpen(open) : nextOpen;
-    if (resolve) {
-      selectRegistry.forEach((closeFn, id) => {
-        if (id !== selectIdRef.current) {
-          closeFn();
-        }
-      });
-    }
-    if (!isOpenControlled) {
-      setOpenState(resolve);
-    }
-    onOpenChange?.(resolve);
-  }, [isOpenControlled, onOpenChange, open]);
-
-  const selectIdRef = React.useRef(null);
-  if (selectIdRef.current === null) {
-    selectIdRef.current = `select-${++selectIdCounter}`;
-  }
-
-  const close = React.useCallback(() => {
-    setOpenState(false);
-  }, []);
-
-  React.useEffect(() => {
-    selectRegistry.set(selectIdRef.current, close);
-    return () => {
-      selectRegistry.delete(selectIdRef.current);
-    };
-  }, [close]);
-
-  const setOpen = React.useCallback((nextOpen) => {
-    setOpenState((prev) => {
-      const valueToSet = typeof nextOpen === "function" ? nextOpen(prev) : nextOpen;
-      if (valueToSet) {
+  const setOpen = React.useCallback(
+    (nextOpen) => {
+      const resolved = typeof nextOpen === "function" ? nextOpen(open) : nextOpen;
+      if (resolved && selectId) {
         selectRegistry.forEach((closeFn, id) => {
-          if (id !== selectIdRef.current) {
+          if (id !== selectId) {
             closeFn();
           }
         });
       }
-      return valueToSet;
-    });
-  }, []);
+      if (!isOpenControlled) {
+        setOpenState(resolved);
+      }
+      onOpenChange?.(resolved);
+    },
+    [isOpenControlled, onOpenChange, open, selectId],
+  );
 
   const registerOption = React.useCallback((optionValue, label) => {
     setOptions((prev) => ({ ...prev, [optionValue]: label }));
@@ -115,34 +150,19 @@ export function Select({ value, defaultValue, onValueChange, children, className
   }, []);
 
   const unregisterOption = React.useCallback((optionValue) => {
-    setOptions((prev) => {
-      if (!(optionValue in prev)) return prev;
-      const next = { ...prev };
-      delete next[optionValue];
-      return next;
-    });
     setOptionOrder((prev) => prev.filter((value) => value !== optionValue));
     optionRefs.current.delete(optionValue);
   }, []);
 
   React.useEffect(() => {
-    if (currentValue != null && options[currentValue]) {
+    if (currentValue == null) {
+      setSelectedLabel("");
+      return;
+    }
+    if (Object.prototype.hasOwnProperty.call(options, currentValue)) {
       setSelectedLabel(options[currentValue]);
     }
   }, [currentValue, options]);
-
-  const updateTriggerRect = React.useCallback(() => {
-    if (!triggerRef.current) return;
-    const rect = triggerRef.current.getBoundingClientRect();
-    setTriggerRect({
-      top: rect.top,
-      left: rect.left,
-      width: rect.width,
-      height: rect.height,
-      right: rect.right,
-      bottom: rect.bottom,
-    });
-  }, []);
 
   const selectValue = React.useCallback(
     (nextValue, label) => {
@@ -157,40 +177,26 @@ export function Select({ value, defaultValue, onValueChange, children, className
   );
 
   React.useEffect(() => {
-    if (!openState) return;
-    updateTriggerRect();
-    const handleResize = () => updateTriggerRect();
-    const handleScroll = () => updateTriggerRect();
-
-    window.addEventListener("resize", handleResize);
-    window.addEventListener("scroll", handleScroll, true);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-      window.removeEventListener("scroll", handleScroll, true);
-    };
-  }, [openState, updateTriggerRect]);
-
-  React.useEffect(() => {
-    if (!openState) {
+    if (!open) {
       setHighlightedIndex(-1);
       return;
     }
     const currentIndex = optionOrder.indexOf(currentValue);
     setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
-  }, [openState, optionOrder, currentValue]);
+  }, [open, optionOrder, currentValue]);
 
   React.useEffect(() => {
-    if (!openState || highlightedIndex < 0) return;
+    if (!open || highlightedIndex < 0) return;
     const valueAtIndex = optionOrder[highlightedIndex];
     if (!valueAtIndex) return;
     const node = optionRefs.current.get(valueAtIndex);
     node?.focus();
-  }, [openState, highlightedIndex, optionOrder]);
+  }, [open, highlightedIndex, optionOrder]);
 
   const contextValue = React.useMemo(
     () => ({
-      open: openState,
+      selectId,
+      open,
       setOpen,
       value: currentValue,
       selectedLabel,
@@ -202,11 +208,12 @@ export function Select({ value, defaultValue, onValueChange, children, className
       optionOrder,
       triggerRef,
       triggerRect,
-      updateTriggerRect,
+      measureTriggerRect,
       optionRefs,
     }),
     [
-      openState,
+      selectId,
+      open,
       setOpen,
       currentValue,
       selectedLabel,
@@ -216,7 +223,7 @@ export function Select({ value, defaultValue, onValueChange, children, className
       highlightedIndex,
       optionOrder,
       triggerRect,
-      updateTriggerRect,
+      measureTriggerRect,
     ],
   );
 
@@ -228,10 +235,10 @@ export function Select({ value, defaultValue, onValueChange, children, className
 }
 
 export const SelectTrigger = React.forwardRef(function SelectTrigger(
-  { className, children, onClick, onKeyDown, ...props },
+  { className, children, onClick, onKeyDown, id: _ignoredId, ...props },
   forwardedRef,
 ) {
-  const { open, setOpen, triggerRef, updateTriggerRect } = useSelectContext();
+  const { open, setOpen, triggerRef, measureTriggerRect, selectId } = useSelectContext();
 
   const assignRef = React.useCallback(
     (node) => {
@@ -241,17 +248,21 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
       } else if (forwardedRef) {
         forwardedRef.current = node;
       }
+      if (node) {
+        measureTriggerRect();
+      }
     },
-    [forwardedRef, triggerRef],
+    [forwardedRef, triggerRef, measureTriggerRect],
   );
 
   const handleToggle = React.useCallback(
     (event) => {
       onClick?.(event);
-      updateTriggerRect();
+      if (event.defaultPrevented) return;
+      measureTriggerRect();
       setOpen((prev) => !prev);
     },
-    [onClick, setOpen, updateTriggerRect],
+    [onClick, setOpen, measureTriggerRect],
   );
 
   const handleKeyDown = React.useCallback(
@@ -261,17 +272,18 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
       const keysToOpen = ["Enter", " ", "ArrowDown", "ArrowUp"];
       if (keysToOpen.includes(event.key)) {
         event.preventDefault();
-        updateTriggerRect();
+        measureTriggerRect();
         setOpen(true);
       }
     },
-    [onKeyDown, setOpen, updateTriggerRect],
+    [onKeyDown, setOpen, measureTriggerRect],
   );
 
   return (
     <button
       type="button"
       ref={assignRef}
+      id={selectId}
       data-state={open ? "open" : "closed"}
       onClick={handleToggle}
       onKeyDown={handleKeyDown}
@@ -283,24 +295,37 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
       aria-expanded={open}
       {...props}
     >
-      <div className="flex flex-1 items-center gap-2 overflow-hidden">{children}</div>
-      <ChevronDown className="ml-2 h-4 w-4 text-muted" aria-hidden="true" />
+      <div className="flex flex-1 items-center gap-2 overflow-hidden text-left">{children}</div>
+      <ChevronDown
+        className={cn("ml-2 h-4 w-4 text-muted transition-transform duration-200", open && "rotate-180")}
+        aria-hidden="true"
+      />
     </button>
   );
 });
 
-export const SelectValue = ({ placeholder, className }) => {
+export const SelectValue = ({ placeholder, className, children }) => {
   const { selectedLabel } = useSelectContext();
-  const hasValue = Boolean(selectedLabel);
+
+  const fallbackLabel = React.useMemo(() => {
+    if (children == null) return "";
+    return getTextFromChildren(children);
+  }, [children]);
+
+  const hasContextValue = Boolean(selectedLabel);
+  const hasFallbackValue = Boolean(fallbackLabel);
+  const content = hasContextValue ? selectedLabel : children ?? fallbackLabel;
+
   return (
-    <span className={cn("truncate", !hasValue && "text-muted", className)}>
-      {hasValue ? selectedLabel : placeholder || "Select"}
+    <span className={cn("truncate", !(hasContextValue || hasFallbackValue) && "text-muted", className)}>
+      {hasContextValue || hasFallbackValue ? content : placeholder || "Select"}
     </span>
   );
 };
 
 export function SelectContent({ className, children, position = "popper", sideOffset = 6, viewportClassName }) {
   const {
+    selectId,
     open,
     setOpen,
     triggerRef,
@@ -308,7 +333,6 @@ export function SelectContent({ className, children, position = "popper", sideOf
     highlightedIndex,
     setHighlightedIndex,
     optionOrder,
-    optionRefs,
   } = useSelectContext();
 
   const contentRef = React.useRef(null);
@@ -371,13 +395,12 @@ export function SelectContent({ className, children, position = "popper", sideOf
   const maxAvailable = Math.min(Math.max(availableSpaceRaw, 160), maxViewportHeight);
 
   const style = {
-    top: shouldOpenUpwards
-      ? triggerRect.top + window.scrollY - sideOffset
-      : triggerRect.bottom + window.scrollY + sideOffset,
-    left: triggerRect.left + window.scrollX,
+    position: "fixed",
+    top: shouldOpenUpwards ? triggerRect.top - sideOffset : triggerRect.bottom + sideOffset,
+    left: triggerRect.left,
+    width: `${triggerRect.width}px`,
     maxHeight: `${maxAvailable}px`,
     transform: shouldOpenUpwards ? "translateY(-100%)" : undefined,
-    "--trigger-width": `${triggerRect.width}px`,
   };
 
   const content = (
@@ -385,12 +408,13 @@ export function SelectContent({ className, children, position = "popper", sideOf
       ref={contentRef}
       style={style}
       className={cn(
-        "z-[9999] w-[var(--trigger-width)] min-w-[12rem] overflow-hidden rounded-xl border border-border/60 bg-surface shadow-e3",
+        "z-[9999] overflow-hidden rounded-xl border border-border/60 bg-surface shadow-e3",
         "data-[placement=top]:origin-bottom data-[placement=bottom]:origin-top",
         className,
       )}
       data-placement={shouldOpenUpwards ? "top" : "bottom"}
       role="listbox"
+      aria-labelledby={selectId}
       tabIndex={-1}
     >
       <div className={cn("max-h-full overflow-y-auto p-1", viewportClassName)}>{children}</div>


### PR DESCRIPTION
## Summary
- allow SelectValue to accept fallback children so triggers can display cached labels even when options unmount
- keep content management Select fields controlled with null defaults and derived labels so chosen values stay visible and post with the form
- mirror the derived label handling in the course edit modal to surface translated labels before opening dropdowns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7b5c37df8832daea867466cbfc07f