### PR TITLE
Improve AscendaIA quiz layout

### DIFF
--- a/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
+++ b/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
@@ -31,27 +31,36 @@ function fakeAscendaIAByLevels({ topic, youtubeUrl, counts }) {
 
 /** ---- small UI helpers ---- */
 function LevelCard({ color = "sky", title, desc, checked, onToggle, value, onChange }) {
-  const ring = `ring-${color}-400/40`;
-  const border = `border-${color}-400/20`;
+  const ring = `ring-${color}-400/30`;
+  const focus = `focus:ring-${color}-400/40`;
   return (
-    <div className={`rounded-2xl border ${border} bg-white/5 p-3 ring-1 ${ring}`}>
-      <div className="mb-2 flex items-start justify-between">
-        <div>
-          <div className="text-base font-semibold">{title}</div>
-          <div className="text-xs text-white/60">{desc}</div>
+    <div
+      className={`flex h-full flex-col gap-4 rounded-2xl border border-border/60 bg-surface/80 p-4 shadow-sm backdrop-blur-sm ring-1 ${ring}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-col gap-1">
+          <h4 className="text-sm font-semibold text-white truncate" title={title}>
+            {title}
+          </h4>
+          <p className="text-sm text-white/70 break-words">{desc}</p>
         </div>
-        <label className="inline-flex cursor-pointer items-center gap-2 text-xs">
-          <input type="checkbox" checked={checked} onChange={onToggle} />
-          Enable
+        <label className="flex shrink-0 items-center gap-2 text-sm text-white/70">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={onToggle}
+            className="h-4 w-4 rounded border border-white/40 bg-transparent accent-current"
+          />
+          <span className="whitespace-nowrap">Enable</span>
         </label>
       </div>
-      <div className="mt-2">
-        <div className="text-[11px] uppercase tracking-wide text-white/50">Questions</div>
-        <div className="mt-1 flex items-center gap-2">
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-white/50">Questions</span>
+        <div className="flex items-center justify-between gap-3">
           <button
             type="button"
             onClick={() => onChange(Math.max(0, (value || 0) - 1))}
-            className="h-8 w-8 rounded-lg border border-white/15 hover:bg-white/5"
+            className="flex h-9 w-9 items-center justify-center rounded-xl border border-white/15 text-lg text-white transition hover:bg-white/5"
           >
             −
           </button>
@@ -60,12 +69,12 @@ function LevelCard({ color = "sky", title, desc, checked, onToggle, value, onCha
             min={0}
             value={value}
             onChange={(e) => onChange(Number(e.target.value))}
-            className="w-full rounded-lg bg-white/5 px-3 py-2 text-center outline-none ring-1 ring-white/10"
+            className={`w-20 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-center text-sm text-white outline-none transition focus:border-white/40 focus:ring-2 ${focus}`}
           />
           <button
             type="button"
             onClick={() => onChange((value || 0) + 1)}
-            className="h-8 w-8 rounded-lg border border-white/15 hover:bg-white/5"
+            className="flex h-9 w-9 items-center justify-center rounded-xl border border-white/15 text-lg text-white transition hover:bg-white/5"
           >
             +
           </button>
@@ -201,15 +210,15 @@ export default function AscendaIASection() {
       </div>
 
       {/* level cards */}
-      <div className="mt-4 grid gap-3 md:grid-cols-3">
+      <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-3">
         <Level code="easy" title="Easy" desc="Quick wins and warm-ups" color="sky" />
         <Level code="intermediate" title="Intermediate" desc="Scenario-based reasoning" color="violet" />
         <Level code="advanced" title="Advanced" desc="Strategic & architectural depth" color="fuchsia" />
       </div>
 
       {/* actions */}
-      <div className="mt-4 flex items-center justify-between">
-        <span className="text-xs text-white/60">
+      <div className="mt-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <span className="text-sm text-white/70 md:text-base">
           Total requested:{" "}
           <span className="rounded-md bg-white/10 px-2 py-0.5 text-white">{totalRequested}</span>
         </span>
@@ -217,7 +226,7 @@ export default function AscendaIASection() {
           type="button"
           onClick={generate}
           disabled={loading || !topic.trim() || totalRequested === 0}
-          className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-violet-500/80 to-fuchsia-500/80 px-4 py-2 font-medium shadow-lg shadow-fuchsia-500/10 transition hover:brightness-110 disabled:opacity-50"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-violet-500/80 to-fuchsia-500/80 px-4 py-2 text-sm font-medium shadow-lg shadow-fuchsia-500/10 transition hover:brightness-110 disabled:opacity-50 md:w-auto"
         >
           {loading ? "Generating…" : "✨ Generate with AscendaIA"}
         </button>


### PR DESCRIPTION
## Summary
- restructure the AscendaIA difficulty cards with a responsive grid and consistent spacing
- align titles, descriptions, checkboxes, and counters to prevent overlap and overflow
- adjust the generate action row to center the button and preserve readable text sizing

## Testing
- npm install *(fails: registry returned 403 for mammoth package)*

------
https://chatgpt.com/codex/tasks/task_e_68e96be3dff8832da5c44807d5d87130