### PR TITLE
Refine AscendaIA card layout

### DIFF
--- a/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
+++ b/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
@@ -3,7 +3,6 @@ import { motion } from "framer-motion";
 
 const ACCENT_STYLES = {
   sky: {
-    cardRing: "ring-sky-400/40",
     checkbox: "text-sky-300 focus-visible:ring-sky-300/40",
     chipBorder: "border-sky-400/40",
     chipBg: "bg-sky-400/10",
@@ -11,7 +10,6 @@ const ACCENT_STYLES = {
     previewBorder: "border-sky-400/40",
   },
   violet: {
-    cardRing: "ring-violet-400/40",
     checkbox: "text-violet-300 focus-visible:ring-violet-300/40",
     chipBorder: "border-violet-400/40",
     chipBg: "bg-violet-400/10",
@@ -19,7 +17,6 @@ const ACCENT_STYLES = {
     previewBorder: "border-violet-400/40",
   },
   fuchsia: {
-    cardRing: "ring-fuchsia-400/40",
     checkbox: "text-fuchsia-300 focus-visible:ring-fuchsia-300/40",
     chipBorder: "border-fuchsia-400/40",
     chipBg: "bg-fuchsia-400/10",
@@ -59,59 +56,56 @@ function fakeAscendaIAByLevels({ topic, youtubeUrl, counts }) {
 /** ---- small UI helpers ---- */
 function LevelCard({ color = "sky", title, desc, checked, onToggle, value, onChange }) {
   const accent = ACCENT_STYLES[color] ?? ACCENT_STYLES.sky;
+  const displayValue = checked ? value ?? 0 : 0;
   return (
     <motion.div
-      whileHover={{ y: -3 }}
-      className={`flex h-full min-w-[260px] w-full flex-col gap-4 rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-sm backdrop-blur-sm ring-1 ${ring} transition-all duration-200 hover:shadow-md`}
+      className={`relative flex h-full min-w-[260px] flex-col rounded-2xl border ${
+        checked ? "border-primary/60" : "border-border/60"
+      } bg-surface/80 p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md hover:z-10 focus-within:z-10`}
     >
       <div className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 flex-col gap-1">
-          <h4 className="truncate text-sm font-semibold text-white" title={title}>
-            {title}
-          </h4>
+        <div className="min-w-0">
+          <p className="text-base font-medium text-white whitespace-normal break-words normal-case">{title}</p>
           <p className="text-sm text-white/70 whitespace-normal break-words normal-case">{desc}</p>
         </div>
-        <label className="flex shrink-0 items-center gap-2 text-xs font-medium text-white/70">
+        <label className="flex items-center gap-2 text-sm text-white/70 select-none">
           <input
             type="checkbox"
             checked={checked}
             onChange={onToggle}
-            className="h-4 w-4 rounded border border-white/40 bg-transparent accent-current"
+            className={`h-4 w-4 rounded border border-white/40 bg-transparent accent-current ${accent.checkbox}`}
             aria-label={`Incluir nível ${title}`}
           />
-          <span className="whitespace-nowrap">Incluir</span>
+          Habilitar
         </label>
       </div>
-      <div className="flex flex-col gap-2">
-        <span className="text-xs font-medium uppercase tracking-wide text-white/50">Questões</span>
-        <div className="flex items-center justify-center gap-3 mt-3">
-          <button
-            type="button"
-            onClick={() => onChange(Math.max(0, (value || 0) - 1))}
-            className="flex h-10 w-10 items-center justify-center rounded-xl border border-white/15 bg-background/60 text-lg text-white transition-all duration-200 hover:bg-white/10"
-            aria-label={`Remover questão de nível ${title}`}
-          >
-            −
-          </button>
-          <input
-            type="number"
-            min={0}
-            value={value ?? 0}
-            onChange={(e) => onChange(Number(e.target.value))}
-            className={`h-10 w-20 rounded-xl border border-white/10 bg-background/80 px-3 text-center text-sm text-white outline-none transition focus:border-white/40 focus:ring-2 ${focus}`}
-            aria-label={`Quantidade de questões nível ${title}`}
-          />
-          <button
-            type="button"
-            onClick={() => onChange((value || 0) + 1)}
-            className="flex h-10 w-10 items-center justify-center rounded-xl border border-white/15 bg-background/60 text-lg text-white transition-all duration-200 hover:bg-white/10"
-            aria-label={`Adicionar questão de nível ${title}`}
-          >
-            +
-          </button>
-        </div>
+
+      <div className="mt-4 text-xs font-semibold uppercase tracking-wide text-white/60">Questões</div>
+
+      <div className="mt-auto flex items-center gap-3 pt-3">
+        <button
+          type="button"
+          onClick={() => onChange(Math.max(0, displayValue - 1))}
+          disabled={!checked || displayValue === 0}
+          className="h-9 w-9 rounded-lg border border-white/15 bg-background/70 text-lg text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+          aria-label={`Remover questão de nível ${title}`}
+        >
+          −
+        </button>
+        <span className="w-10 text-center tabular-nums text-white" aria-live="polite">
+          {displayValue}
+        </span>
+        <button
+          type="button"
+          onClick={() => onChange(displayValue + 1)}
+          disabled={!checked}
+          className="h-9 w-9 rounded-lg border border-white/15 bg-background/70 text-lg text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+          aria-label={`Adicionar questão de nível ${title}`}
+        >
+          +
+        </button>
       </div>
-    </div>
+    </motion.div>
   );
 }
 
@@ -179,6 +173,22 @@ export default function AscendaIASection() {
     (sel.intermediate ? counts.intermediate : 0) +
     (sel.advanced ? counts.advanced : 0);
 
+  const handleToggleLevel = (code) => {
+    setSel((prev) => ({
+      ...prev,
+      [code]: !prev[code],
+    }));
+  };
+
+  const handleCountChange = (code, value) => {
+    const numeric = Number(value);
+    const safe = Number.isFinite(numeric) ? numeric : 0;
+    setCounts((prev) => ({
+      ...prev,
+      [code]: Math.max(0, safe),
+    }));
+  };
+
   const generate = async () => {
     const topicClean = topic.trim();
     const youtubeClean = youtubeUrl.trim();
@@ -207,7 +217,6 @@ export default function AscendaIASection() {
   const canGenerate =
     totalRequested > 0 &&
     (topic.trim().length > 0 || youtubeUrl.trim().length > 0);
-  const disableGenerate = loading || !canGenerate;
 
   const save = () => {
     const key = "ascenda_quizzes";
@@ -272,26 +281,31 @@ export default function AscendaIASection() {
       </div>
 
       {/* level cards */}
-      <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-3">
-        <Level code="easy" title="Básico" desc="Vitórias rápidas e aquecimento" color="sky" />
-        <Level code="intermediate" title="Intermediário" desc="Raciocínio baseado em cenários" color="violet" />
-        <Level code="advanced" title="Avançado" desc="Profundidade estratégica e arquitetural" color="fuchsia" />
+      <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-3 items-stretch isolate">
+        {levels.map((level) => (
+          <LevelCard
+            key={level.code}
+            color={level.accent}
+            title={level.title}
+            desc={level.desc}
+            checked={Boolean(sel[level.code])}
+            onToggle={() => handleToggleLevel(level.code)}
+            value={counts[level.code]}
+            onChange={(next) => handleCountChange(level.code, next)}
+          />
+        ))}
       </div>
 
       {/* actions */}
-      <div className="mt-8 flex flex-col items-center gap-3 text-center">
-        <span
-          className="text-sm text-white/80"
-          aria-live="polite"
-        >
-          Total solicitado:{" "}
-          <span className="rounded-md bg-white/10 px-2 py-0.5 font-semibold text-white">{totalRequested}</span>
-        </span>
+      <div className="mt-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <p className="text-sm text-white/80" aria-live="polite">
+          Total solicitado: <span className="font-semibold text-white">{totalRequested}</span>
+        </p>
         <button
           type="button"
           onClick={generate}
           disabled={loading || !canGenerate}
-          className="inline-flex w-full max-w-xs items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-violet-500/80 via-violet-500/70 to-fuchsia-500/80 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-fuchsia-500/10 transition-all duration-200 hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
+          className="w-full rounded-2xl bg-gradient-to-r from-primary/90 to-fuchsia-600/80 px-5 py-3 text-sm font-semibold text-white shadow-md transition hover:brightness-110 disabled:opacity-60 md:w-auto"
         >
           {loading ? "Gerando…" : "✨ Gerar com AscendaIA"}
         </button>


### PR DESCRIPTION
## Summary
- restructure the AscendaIA level cards to keep heights aligned, pin the controls to the footer, and highlight enabled states
- update the card grid container and action footer spacing to match the stable layout and button alignment guidelines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9965d1344832da6a4d43089e7c5e9