### PR TITLE
Fix AscendaIA quiz level grid responsiveness

### DIFF
--- a/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
+++ b/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
@@ -300,7 +300,7 @@ export default function AscendaIASection() {
       </div>
 
       {/* level cards */}
-      <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-3">
+      <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {levels.map((level) => (
           <LevelCard
             key={level.code}


### PR DESCRIPTION
## Summary
- adjust the AscendaIA quiz level grid to use two columns on medium screens and three columns on large screens for better spacing

## Testing
- npm install *(fails: 403 Forbidden when fetching mammoth package from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e9be6fee28832d85e22feb5639e7ad