### PR TITLE
Fix quiz level cards layout

### DIFF
--- a/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
+++ b/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
@@ -65,7 +65,7 @@ function DifficultyCard({ title, desc, checked, onToggle, value, onChange, color
     <motion.div
       whileHover={{ y: -3 }}
       className={cn(
-        "flex h-full min-h-[200px] w-full flex-col gap-4 rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-sm backdrop-blur-sm ring-1 transition-all duration-200 hover:shadow-md",
+        "quiz-card flex h-full min-h-[200px] w-full flex-col gap-4 rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-sm backdrop-blur-sm ring-1 transition-all duration-200 hover:shadow-md",
         accent.cardRing,
       )}
     >
@@ -302,7 +302,7 @@ export default function AscendaIASection({ asModal = false }) {
       </div>
 
       {/* level cards */}
-      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+      <div id="quiz-cards" className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {levels.map((level) => (
           <LevelCard
             key={level.code}


### PR DESCRIPTION
## Summary
- ensure the Ascenda quiz level grid has an explicit container hook for the layout hotfix
- tag each level card with the quiz-card class so the cards respect the min-width styling
- adjust responsive breakpoints so two cards show up on small screens and three on large screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea70a75750832db4b8686d2505b926