### PR TITLE
Fix layout isolation for AscendaIA quiz section

### DIFF
--- a/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
+++ b/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
@@ -275,8 +275,8 @@ export default function AscendaIASection({ asModal = false }) {
 
   const content = (
     <>
-      <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:gap-8">
-        <div className="flex-1 space-y-6">
+      <div className="quiz-layout">
+        <div className="quiz-main">
           {/* header */}
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div className="space-y-1">
@@ -317,7 +317,7 @@ export default function AscendaIASection({ asModal = false }) {
           </div>
 
           {/* level cards */}
-          <div id="quiz-cards" className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {levels.map((level) => (
               <LevelCard
                 key={level.code}
@@ -333,29 +333,13 @@ export default function AscendaIASection({ asModal = false }) {
           </div>
         </div>
 
-        <aside className="w-full shrink-0 space-y-5 rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-white/70 xl:max-w-xs">
+        <aside className="quiz-summary space-y-5 rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-white/70">
           <div className="space-y-1">
             <h4 className="text-base font-semibold text-white">Resumo do pedido</h4>
             <p className="text-xs text-white/60">
               Ajuste os níveis e quantidades antes de gerar o quiz com a AscendaIA.
             </p>
           </div>
-
-      {/* level cards */}
-      <div id="quiz-cards" className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {levels.map((level) => (
-          <LevelCard
-            key={level.code}
-            color={level.accent}
-            title={level.title}
-            desc={level.desc}
-            checked={Boolean(sel[level.code])}
-            onToggle={() => handleToggleLevel(level.code)}
-            value={counts[level.code]}
-            onChange={(next) => handleCountChange(level.code, next)}
-          />
-        ))}
-      </div>
 
           <button
             type="button"

--- a/Ascenda Padrinho att/src/main.jsx
+++ b/Ascenda Padrinho att/src/main.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
-import './styles/quiz-fix.css';
 import './styles/ascenda-quiz-scope.css';
 import 'flag-icons/css/flag-icons.min.css';
 import { LanguageProvider } from './i18n';

--- a/Ascenda Padrinho att/src/styles/ascenda-quiz-scope.css
+++ b/Ascenda Padrinho att/src/styles/ascenda-quiz-scope.css
@@ -3,7 +3,6 @@
 [data-quiz-scope] * {
   writing-mode: horizontal-tb !important;
   text-orientation: mixed !important;
-  transform: none !important;
   rotate: 0deg !important;
 }
 
@@ -26,4 +25,35 @@
 /* Impedir scroll horizontal no bloco (sem mascarar bugs visuais) */
 [data-quiz-scope] {
   overflow-x: hidden;
+}
+
+/* Layout fixo em duas colunas com barra lateral estável */
+[data-quiz-scope] .quiz-layout {
+  display: grid;
+  gap: 1.5rem;
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+[data-quiz-scope] .quiz-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+[data-quiz-scope] .quiz-summary {
+  width: 100%;
+  max-width: 320px;
+  position: relative;
+}
+
+@media (min-width: 1024px) {
+  [data-quiz-scope] .quiz-layout {
+    grid-template-columns: minmax(0, 1fr) 320px;
+  }
+
+  [data-quiz-scope] .quiz-summary {
+    width: 320px;
+  }
 }


### PR DESCRIPTION
## Summary
- switch the AscendaIA quiz section to a scoped grid layout so the main content and sidebar remain aligned
- remove the duplicated card grid from the sidebar and rely on min-width safe defaults to prevent text squeezing
- extend the section-specific CSS to enforce horizontal text flow, keep animations intact, and lock in the responsive column template
- drop the stray quiz-fix stylesheet import so Vite no longer errors during build analysis

## Testing
- npm run build *(fails: vite not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eaac251db8832d91bf3262af1e88a4