### PR TITLE
Convert AscendaIA quiz section into modal workflow

### DIFF
--- a/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
+++ b/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { cn } from "@/utils";
 
@@ -6,26 +6,14 @@ const ACCENT_STYLES = {
   sky: {
     cardRing: "ring-sky-400/20",
     checkbox: "text-sky-300 focus-visible:ring-sky-300/40",
-    chipBorder: "border-sky-400/40",
-    chipBg: "bg-sky-400/10",
-    chipText: "text-sky-100",
-    previewBorder: "border-sky-400/40",
   },
   violet: {
     cardRing: "ring-violet-400/20",
     checkbox: "text-violet-300 focus-visible:ring-violet-300/40",
-    chipBorder: "border-violet-400/40",
-    chipBg: "bg-violet-400/10",
-    chipText: "text-violet-100",
-    previewBorder: "border-violet-400/40",
   },
   fuchsia: {
     cardRing: "ring-fuchsia-400/20",
     checkbox: "text-fuchsia-300 focus-visible:ring-fuchsia-300/40",
-    chipBorder: "border-fuchsia-400/40",
-    chipBg: "bg-fuchsia-400/10",
-    chipText: "text-fuchsia-100",
-    previewBorder: "border-fuchsia-400/40",
   },
 };
 
@@ -127,40 +115,16 @@ function DifficultyCard({ title, desc, checked, onToggle, value, onChange, color
 
 export const LevelCard = DifficultyCard;
 
-function StatChip({ label, count, color = "sky" }) {
-  const accent = ACCENT_STYLES[color] ?? ACCENT_STYLES.sky;
-  return (
-    <span
-      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium ${accent.chipBorder} ${accent.chipBg} ${accent.chipText}`}
-    >
-      {label} <b className="text-white">{count}</b>
-    </span>
-  );
-}
-
-function PreviewCol({ label, items, color = "sky" }) {
-  const accent = ACCENT_STYLES[color] ?? ACCENT_STYLES.sky;
-  return (
-    <div className={`rounded-xl border p-3 ${accent.previewBorder}`}>
-      <div className="mb-2 text-sm font-semibold">{label}</div>
-      <ul className="max-h-56 space-y-1 overflow-auto pr-1 text-sm text-white/70">
-        {items.length === 0 && <li className="text-white/40">Sem itens</li>}
-        {items.slice(0, 8).map((q) => (
-          <li key={q.id}>• {q.prompt}</li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
 /** ---- main component ---- */
-export default function AscendaIASection({ asModal = false }) {
+export default function AscendaIASection({ open = false, onClose, onComplete }) {
   const [topic, setTopic] = useState("");
   const [youtubeUrl, setYoutubeUrl] = useState("");
   const [sel, setSel] = useState({ easy: true, intermediate: true, advanced: false });
   const [counts, setCounts] = useState({ easy: 4, intermediate: 4, advanced: 2 });
   const [loading, setLoading] = useState(false);
-  const [quiz, setQuiz] = useState(null);
+  const overlayRef = useRef(null);
+  const topicInputRef = useRef(null);
+  const cancellationRef = useRef(false);
 
   const levels = useMemo(
     () => [
@@ -223,10 +187,14 @@ export default function AscendaIASection({ asModal = false }) {
     if (!req.counts.easy && !req.counts.intermediate && !req.counts.advanced) return;
 
     setLoading(true);
-    setQuiz(null);
+    cancellationRef.current = false;
+
     try {
       const result = await fakeAscendaIAByLevels(req);
-      setQuiz(result);
+      if (!cancellationRef.current) {
+        onComplete?.(result);
+        onClose?.();
+      }
     } finally {
       setLoading(false);
     }
@@ -236,204 +204,196 @@ export default function AscendaIASection({ asModal = false }) {
     totalRequested > 0 &&
     (topic.trim().length > 0 || youtubeUrl.trim().length > 0);
 
-  const save = () => {
-    const key = "ascenda_quizzes";
-    const list = JSON.parse(localStorage.getItem(key) || "[]");
-    list.push({
-      id: `quiz_${Date.now()}`,
-      topic: quiz.topic,
-      source: quiz.source,
-      createdBy: quiz.createdBy,
-      createdAt: quiz.createdAt,
-      items: [...quiz.easy, ...quiz.intermediate, ...quiz.advanced],
-      breakdown: {
-        easy: quiz.easy.length,
-        intermediate: quiz.intermediate.length,
-        advanced: quiz.advanced.length,
-      },
-      status: "draft",
-    });
-    localStorage.setItem(key, JSON.stringify(list));
-    alert("✅ Quiz saved locally!");
-  };
-
   const summaryItems = levels.map((level) => ({
     ...level,
     enabled: Boolean(sel[level.code]),
     total: sel[level.code] ? Number(counts[level.code] || 0) : 0,
   }));
+  useEffect(() => {
+    if (!open) {
+      setTopic("");
+      setYoutubeUrl("");
+      setSel({ easy: true, intermediate: true, advanced: false });
+      setCounts({ easy: 4, intermediate: 4, advanced: 2 });
+      setLoading(false);
+      cancellationRef.current = false;
+      return;
+    }
 
-  const wrapperProps = {
-    role: "region",
-    "aria-label": "Gerar Quizzes",
-    "data-quiz-scope": "",
-    className: cn(
-      "w-full space-y-8 rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm sm:p-8",
-      asModal ? "max-w-full" : "mx-auto max-w-6xl",
-    ),
+    cancellationRef.current = false;
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        cancellationRef.current = true;
+        onClose?.();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    const focusTimer = window.setTimeout(() => {
+      topicInputRef.current?.focus();
+    }, 150);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      window.clearTimeout(focusTimer);
+    };
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  const handleOverlayMouseDown = (event) => {
+    if (event.target === overlayRef.current) {
+      event.preventDefault();
+      cancellationRef.current = true;
+      onClose?.();
+    }
   };
 
-  const content = (
-    <>
-      <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:gap-8">
-        <div className="flex-1 space-y-6">
-          {/* header */}
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-            <div className="space-y-1">
-              <h3 className="text-xl font-semibold text-white">AscendaIA – Gerar Quizzes</h3>
-              <p className="text-sm text-white/70 whitespace-normal break-words normal-case">
-                Gere quizzes a partir de um tópico ou link do YouTube. Escolha os níveis e quantidades desejadas.
-              </p>
+  return (
+    <div
+      ref={overlayRef}
+      className="ascenda-quiz-overlay"
+      role="presentation"
+      onMouseDown={handleOverlayMouseDown}
+    >
+      <motion.div
+        data-quiz-scope=""
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ascenda-quiz-title"
+        className={cn(
+          "quiz-modal w-full space-y-6 rounded-3xl border border-border/60 bg-surface/90 p-6 shadow-e1 backdrop-blur-xl sm:p-8",
+        )}
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.25, ease: "easeOut" }}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="quiz-header flex flex-col gap-2">
+          <h3 id="ascenda-quiz-title" className="text-xl font-semibold text-white">
+            AscendaIA – Gerar Quizzes
+          </h3>
+          <p className="text-sm text-white/70 whitespace-normal break-words normal-case">
+            Gere quizzes a partir de um tópico ou link do YouTube. Escolha os níveis e quantidades desejadas.
+          </p>
+        </div>
+
+        <div className="quiz-body space-y-6">
+          <div className="quiz-layout">
+            <div className="quiz-main">
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="flex flex-col gap-2 text-sm text-white/70">
+                  <span className="text-sm font-medium text-white">Tópico</span>
+                  <input
+                    ref={topicInputRef}
+                    className="h-10 w-full rounded-xl border border-border/60 bg-background/80 px-3 text-sm text-white outline-none transition focus:ring-2 focus:ring-primary/40"
+                    placeholder="Tópico (ex.: React, Lógica, SQL)"
+                    value={topic}
+                    onChange={(e) => setTopic(e.target.value)}
+                    aria-label="Tópico do quiz"
+                  />
+                </label>
+                <label className="flex flex-col gap-2 text-sm text-white/70">
+                  <span className="text-sm font-medium text-white">Link do YouTube</span>
+                  <input
+                    className="h-10 w-full rounded-xl border border-border/60 bg-background/80 px-3 text-sm text-white outline-none transition focus:ring-2 focus:ring-primary/40"
+                    placeholder="Link do YouTube (opcional)"
+                    value={youtubeUrl}
+                    onChange={(e) => setYoutubeUrl(e.target.value)}
+                    aria-label="Link do YouTube para referência"
+                  />
+                </label>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {levels.map((level) => (
+                  <LevelCard
+                    key={level.code}
+                    color={level.accent}
+                    title={level.title}
+                    desc={level.desc}
+                    checked={Boolean(sel[level.code])}
+                    onToggle={() => handleToggleLevel(level.code)}
+                    value={counts[level.code]}
+                    onChange={(next) => handleCountChange(level.code, next)}
+                  />
+                ))}
+              </div>
             </div>
-            {quiz && (
-              <span className="inline-flex items-center rounded-full border border-emerald-400/40 bg-emerald-400/15 px-3 py-1 text-xs font-medium text-emerald-200">
-                Rascunho pronto
-              </span>
-            )}
-          </div>
 
-          {/* inputs */}
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="flex flex-col gap-2 text-sm text-white/70">
-              <span className="text-sm font-medium text-white">Tópico</span>
-              <input
-                className="h-10 w-full rounded-xl border border-border/60 bg-background/80 px-3 text-sm text-white outline-none transition focus:ring-2 focus:ring-primary/40"
-                placeholder="Tópico (ex.: React, Lógica, SQL)"
-                value={topic}
-                onChange={(e) => setTopic(e.target.value)}
-                aria-label="Tópico do quiz"
-              />
-            </label>
-            <label className="flex flex-col gap-2 text-sm text-white/70">
-              <span className="text-sm font-medium text-white">Link do YouTube</span>
-              <input
-                className="h-10 w-full rounded-xl border border-border/60 bg-background/80 px-3 text-sm text-white outline-none transition focus:ring-2 focus:ring-primary/40"
-                placeholder="Link do YouTube (opcional)"
-                value={youtubeUrl}
-                onChange={(e) => setYoutubeUrl(e.target.value)}
-                aria-label="Link do YouTube para referência"
-              />
-            </label>
-          </div>
+            <aside className="quiz-summary space-y-5 rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-white/70">
+              <div className="space-y-1">
+                <h4 className="text-base font-semibold text-white">Resumo do pedido</h4>
+                <p className="text-xs text-white/60">
+                  Ajuste os níveis e quantidades antes de gerar o quiz com a AscendaIA.
+                </p>
+              </div>
 
-          {/* level cards */}
-          <div id="quiz-cards" className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {levels.map((level) => (
-              <LevelCard
-                key={level.code}
-                color={level.accent}
-                title={level.title}
-                desc={level.desc}
-                checked={Boolean(sel[level.code])}
-                onToggle={() => handleToggleLevel(level.code)}
-                value={counts[level.code]}
-                onChange={(next) => handleCountChange(level.code, next)}
-              />
-            ))}
+              <ul className="space-y-3">
+                {summaryItems.map((item) => (
+                  <li
+                    key={item.code}
+                    className={cn(
+                      "flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-background/40 px-3 py-2",
+                      item.enabled ? "text-white" : "text-white/50",
+                    )}
+                  >
+                    <span className="flex items-center gap-2 text-sm font-medium">
+                      <span
+                        className={cn(
+                          "h-2.5 w-2.5 rounded-full",
+                          SUMMARY_DOT_COLORS[item.accent] ?? "bg-white/40",
+                        )}
+                      />
+                      {item.title}
+                    </span>
+                    <span className="text-sm font-semibold">{item.total}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/70">
+                Total solicitado: <span className="font-semibold text-white">{totalRequested}</span> questões
+              </div>
+
+              {loading ? (
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10" role="status" aria-live="polite">
+                  <div className="h-full w-1/2 animate-loading-stripes rounded-full bg-gradient-to-r from-violet-400/60 via-violet-300/80 to-fuchsia-400/60" />
+                </div>
+              ) : (
+                <p className="text-xs text-white/60">
+                  Informe um tópico ou link do YouTube e mantenha ao menos um nível selecionado para habilitar a geração.
+                </p>
+              )}
+            </aside>
           </div>
         </div>
 
-        <aside className="w-full shrink-0 space-y-5 rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-white/70 xl:max-w-xs">
-          <div className="space-y-1">
-            <h4 className="text-base font-semibold text-white">Resumo do pedido</h4>
-            <p className="text-xs text-white/60">
-              Ajuste os níveis e quantidades antes de gerar o quiz com a AscendaIA.
-            </p>
-          </div>
-
-      {/* level cards */}
-      <div id="quiz-cards" className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {levels.map((level) => (
-          <LevelCard
-            key={level.code}
-            color={level.accent}
-            title={level.title}
-            desc={level.desc}
-            checked={Boolean(sel[level.code])}
-            onToggle={() => handleToggleLevel(level.code)}
-            value={counts[level.code]}
-            onChange={(next) => handleCountChange(level.code, next)}
-          />
-        ))}
-      </div>
-
+        <div className="quiz-footer flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={() => {
+              cancellationRef.current = true;
+              onClose?.();
+            }}
+            className="w-full rounded-2xl border border-white/15 bg-transparent px-4 py-3 text-sm font-medium text-white transition hover:bg-white/10 sm:w-auto"
+          >
+            Cancelar
+          </button>
           <button
             type="button"
             onClick={generate}
             disabled={loading || !canGenerate}
-            className="flex w-full items-center justify-center rounded-2xl bg-gradient-to-r from-primary/90 to-fuchsia-600/80 px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+            className="w-full rounded-2xl bg-gradient-to-r from-primary/90 to-fuchsia-600/80 px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
           >
-            {loading ? "Gerando…" : "✨ Gerar com AscendaIA"}
+            {loading ? "Gerando…" : "Gerar"}
           </button>
-
-          {loading ? (
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10" role="status" aria-live="polite">
-              <div className="h-full w-1/2 animate-loading-stripes rounded-full bg-gradient-to-r from-violet-400/60 via-violet-300/80 to-fuchsia-400/60" />
-            </div>
-          ) : quiz ? (
-            <p className="text-xs font-medium text-emerald-200">
-              Quiz pronto! Revise o conteúdo abaixo ou salve como rascunho.
-            </p>
-          ) : (
-            <p className="text-xs text-white/60">
-              Informe um tópico ou link do YouTube e mantenha ao menos um nível selecionado para habilitar a geração.
-            </p>
-          )}
-        </aside>
-      </div>
-
-      {/* preview */}
-      {quiz && (
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-4 sm:p-5">
-          <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div className="text-sm text-white/70">
-              <span className="font-semibold">{quiz.topic}</span>
-              <span className="mx-2 hidden md:inline">•</span>
-              <span className="block md:inline">
-                Total de <span className="font-semibold">{quiz.easy.length + quiz.intermediate.length + quiz.advanced.length}</span> questões
-              </span>
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <StatChip label="Básico" count={quiz.easy.length} color="sky" />
-              <StatChip label="Intermediário" count={quiz.intermediate.length} color="violet" />
-              <StatChip label="Avançado" count={quiz.advanced.length} color="fuchsia" />
-            </div>
-          </div>
-
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-            <PreviewCol label="Básico" color="sky" items={quiz.easy} />
-            <PreviewCol label="Intermediário" color="violet" items={quiz.intermediate} />
-            <PreviewCol label="Avançado" color="fuchsia" items={quiz.advanced} />
-          </div>
-
-          <div className="mt-5 flex flex-col justify-end gap-2 sm:flex-row">
-            <button
-              type="button"
-              onClick={() => setQuiz(null)}
-              className="rounded-lg border border-white/15 px-3 py-2 text-sm transition-all duration-200 hover:bg-white/5"
-            >
-              Descartar
-            </button>
-            <button
-              type="button"
-              onClick={save}
-              className="rounded-lg bg-emerald-500/80 px-4 py-2 text-sm font-semibold text-emerald-950 shadow-md transition-all duration-200 hover:brightness-110"
-            >
-              Salvar quiz
-            </button>
-          </div>
         </div>
-      )}
-    </>
-  );
-
-  if (asModal) {
-    return (
-      <motion.div {...wrapperProps}>
-        {content}
       </motion.div>
-    );
-  }
-
-  return <section {...wrapperProps}>{content}</section>;
+    </div>
+  );
 }

--- a/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
+++ b/Ascenda Padrinho att/src/components/content/CourseUploadForm.jsx
@@ -29,6 +29,8 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
   const [isUploading, setIsUploading] = useState(false);
   const [file, setFile] = useState(null);
   const [previewData, setPreviewData] = useState(null);
+  const [quizDraft, setQuizDraft] = useState(null);
+  const [isQuizModalOpen, setQuizModalOpen] = useState(false);
   const { t } = useTranslation();
   const categoryOptions = useMemo(
     () => [
@@ -80,6 +82,10 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
 
   const handleVideoIdChange = React.useCallback((videoId) => {
     setYoutubeVideoId(videoId);
+  }, []);
+
+  const handleQuizComplete = React.useCallback((quiz) => {
+    setQuizDraft(quiz);
   }, []);
 
   const handleSubmit = React.useCallback(async (e) => {
@@ -282,9 +288,66 @@ export default function CourseUploadForm({ onSuccess, onPreview }) {
               </div>
             </div>
 
-            <div className="w-full overflow-x-hidden">
-              <AscendaIASection />
+            <div className="space-y-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setQuizModalOpen(true)}
+                className="w-full border-brand/30 text-brand hover:bg-brand/10"
+              >
+                ✨ AscendaIA — Gerar Quizzes
+              </Button>
+
+              {quizDraft && (
+                <div className="rounded-2xl border border-emerald-400/40 bg-emerald-400/10 p-4 text-sm text-emerald-100">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="space-y-1">
+                      <p className="text-base font-semibold text-emerald-50">{quizDraft.topic}</p>
+                      {quizDraft.source && (
+                        <p className="text-xs text-emerald-200/80">Fonte: {quizDraft.source}</p>
+                      )}
+                      <p className="text-xs text-emerald-200/70">
+                        Total de {quizDraft.easy.length + quizDraft.intermediate.length + quizDraft.advanced.length} questões geradas.
+                      </p>
+                    </div>
+                    <div className="flex flex-col gap-1 text-xs text-emerald-100">
+                      <span>
+                        Básico: <b>{quizDraft.easy.length}</b>
+                      </span>
+                      <span>
+                        Intermediário: <b>{quizDraft.intermediate.length}</b>
+                      </span>
+                      <span>
+                        Avançado: <b>{quizDraft.advanced.length}</b>
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-emerald-50">
+                    <button
+                      type="button"
+                      onClick={() => setQuizDraft(null)}
+                      className="rounded-lg border border-emerald-200/40 px-3 py-1 text-emerald-50 transition hover:bg-emerald-200/10"
+                    >
+                      Descartar rascunho
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setQuizModalOpen(true)}
+                      className="rounded-lg border border-transparent bg-emerald-400/30 px-3 py-1 font-medium text-emerald-950 transition hover:bg-emerald-300/70"
+                    >
+                      Gerar novamente
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
+
+            <AscendaIASection
+              open={isQuizModalOpen}
+              onClose={() => setQuizModalOpen(false)}
+              onComplete={handleQuizComplete}
+            />
 
             {previewData && (
               <Button

--- a/Ascenda Padrinho att/src/main.jsx
+++ b/Ascenda Padrinho att/src/main.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
-import './styles/quiz-fix.css';
 import './styles/ascenda-quiz-scope.css';
 import 'flag-icons/css/flag-icons.min.css';
 import { LanguageProvider } from './i18n';

--- a/Ascenda Padrinho att/src/styles/ascenda-quiz-scope.css
+++ b/Ascenda Padrinho att/src/styles/ascenda-quiz-scope.css
@@ -1,9 +1,40 @@
+/* Modal container & overlay */
+.ascenda-quiz-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 4vw, 2.5rem);
+  background: rgba(8, 11, 24, 0.75);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  overflow-y: auto;
+}
+
+[data-quiz-scope].quiz-modal {
+  max-width: 900px;
+  width: min(900px, 100%);
+  max-height: min(90vh, 820px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  outline: none;
+}
+
+@media (max-width: 640px) {
+  .ascenda-quiz-overlay {
+    padding: clamp(0.75rem, 6vw, 1.25rem);
+    align-items: flex-start;
+  }
+}
+
 /* Isolamento: neutraliza efeitos do CSS global dentro da aba */
 [data-quiz-scope],
 [data-quiz-scope] * {
   writing-mode: horizontal-tb !important;
   text-orientation: mixed !important;
-  transform: none !important;
   rotate: 0deg !important;
 }
 
@@ -26,4 +57,46 @@
 /* Impedir scroll horizontal no bloco (sem mascarar bugs visuais) */
 [data-quiz-scope] {
   overflow-x: hidden;
+}
+
+/* Layout fixo em duas colunas com barra lateral estável */
+[data-quiz-scope] .quiz-layout {
+  display: grid;
+  gap: 1.5rem;
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+[data-quiz-scope] .quiz-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+[data-quiz-scope] .quiz-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+[data-quiz-scope] .quiz-summary {
+  width: 100%;
+  max-width: 320px;
+  position: relative;
+}
+
+@media (min-width: 1024px) {
+  [data-quiz-scope] .quiz-layout {
+    grid-template-columns: minmax(0, 1fr) 320px;
+  }
+
+  [data-quiz-scope] .quiz-summary {
+    width: 320px;
+  }
+}
+
+[data-quiz-scope] .quiz-footer {
+  margin-top: auto;
 }


### PR DESCRIPTION
## Summary
- convert the AscendaIA quiz generator into a cancellable modal with scoped overlay, keyboard escape handling, and bottom-aligned actions
- add a trigger button and generated-quiz summary panel to the course upload form so users can reopen or discard drafts after the modal closes
- extend the AscendaIA scoped stylesheet with overlay, modal, and grid adjustments to keep the dialog centered and responsive without global side effects

## Testing
- npm run build *(fails: vite not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eaac251db8832d91bf3262af1e88a4