### PR TITLE
Refine Ascenda quiz level layout

### DIFF
--- a/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
+++ b/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
@@ -71,31 +71,30 @@ function DifficultyCard({ title, desc, checked, onToggle, value, onChange, color
     <motion.div
       whileHover={{ y: -3 }}
       className={cn(
-        "quiz-card flex h-full min-h-[200px] w-full flex-col gap-4 rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-sm backdrop-blur-sm ring-1 transition-all duration-200 hover:shadow-md",
+        "quiz-card flex h-full min-h-[200px] w-full flex-col rounded-2xl border border-border/60 bg-surface/80 p-5 shadow-sm backdrop-blur-sm ring-1 transition-all duration-200 hover:shadow-md",
         accent.cardRing,
       )}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 space-y-1">
-          <p className="text-base font-semibold whitespace-normal break-words normal-case">{title}</p>
-          <p className="text-sm text-white/70 whitespace-normal break-words normal-case">{desc}</p>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-lg font-semibold text-white whitespace-normal break-words normal-case">{title}</h3>
+          <label className="flex shrink-0 items-center gap-2 text-xs font-medium text-white/70">
+            <input
+              type="checkbox"
+              checked={checked}
+              onChange={() => onToggle?.()}
+              className={`h-4 w-4 rounded border border-white/40 bg-transparent accent-current ${accent.checkbox}`}
+              aria-label={`Incluir nível ${title}`}
+            />
+            <span>Incluir</span>
+          </label>
         </div>
-        <label className="flex shrink-0 items-center gap-2 text-xs font-medium text-white/70">
-          <input
-            type="checkbox"
-            checked={checked}
-            onChange={() => onToggle?.()}
-            className={`h-4 w-4 rounded border border-white/40 bg-transparent accent-current ${accent.checkbox}`}
-            aria-label={`Incluir nível ${title}`}
-          />
-          <span>Incluir</span>
-        </label>
+        <p className="text-sm text-white/70 whitespace-normal break-words normal-case">{desc}</p>
       </div>
-      <div className="mt-auto flex items-end justify-between gap-3 pt-4">
-        <div className="flex flex-col text-xs uppercase tracking-wide text-white/50">
-          <span className="font-medium">Questões</span>
-          <span className="text-[11px] text-white/40">Disponíveis para este nível</span>
-        </div>
+      <div className="mt-auto flex items-end justify-between gap-3 pt-5">
+        <p className="max-w-[140px] text-[11px] uppercase tracking-[0.08em] text-white/60">
+          Questões disponíveis para este nível
+        </p>
         <div className="flex items-center gap-2">
           <button
             type="button"
@@ -166,7 +165,7 @@ export default function AscendaIASection({ asModal = false }) {
     () => [
       {
         code: "easy",
-        title: "Básico",
+        title: "Iniciante",
         desc: "Vitórias rápidas e aquecimento",
         accent: "sky",
       },
@@ -317,18 +316,19 @@ export default function AscendaIASection({ asModal = false }) {
           </div>
 
           {/* level cards */}
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="flex flex-col gap-4 md:flex-row md:flex-wrap md:gap-6">
             {levels.map((level) => (
-              <LevelCard
-                key={level.code}
-                color={level.accent}
-                title={level.title}
-                desc={level.desc}
-                checked={Boolean(sel[level.code])}
-                onToggle={() => handleToggleLevel(level.code)}
-                value={counts[level.code]}
-                onChange={(next) => handleCountChange(level.code, next)}
-              />
+              <div key={level.code} className="w-full md:flex-1">
+                <LevelCard
+                  color={level.accent}
+                  title={level.title}
+                  desc={level.desc}
+                  checked={Boolean(sel[level.code])}
+                  onToggle={() => handleToggleLevel(level.code)}
+                  value={counts[level.code]}
+                  onChange={(next) => handleCountChange(level.code, next)}
+                />
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reorganized the Ascenda quiz level cards into a responsive horizontal layout with consistent spacing
- restructured the card header, description, and question selector to match the desired hierarchy and wording
- renamed the beginner level to "Iniciante" for clarity

## Testing
- npm install --legacy-peer-deps *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/mammoth)*

------
https://chatgpt.com/codex/tasks/task_e_68eb009c72c8832d87bb6fc43ad1d74e