### PR TITLE
Fix Ascenda quiz layout height overflow

### DIFF
--- a/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
+++ b/Ascenda Padrinho att/src/components/ascenda/AscendaIASection.jsx
@@ -152,7 +152,7 @@ function PreviewCol({ label, items, color = "sky" }) {
   return (
     <div className={`rounded-xl border p-3 ${accent.previewBorder}`}>
       <div className="mb-2 text-sm font-semibold">{label}</div>
-      <ul className="max-h-56 space-y-1 overflow-auto pr-1 text-sm text-white/70">
+      <ul className="quiz-preview-list max-h-56 space-y-1 overflow-auto pr-1 text-sm text-white/70">
         {items.length === 0 && <li className="text-white/40">Sem itens</li>}
         {items.slice(0, 8).map((q) => (
           <li key={q.id}>• {q.prompt}</li>
@@ -283,11 +283,12 @@ export default function AscendaIASection({ asModal = false, variant = "standalon
       "w-full rounded-2xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm sm:p-7",
       asModal ? "max-w-full" : "",
     ),
+    style: { height: "auto", minHeight: 0, overflow: "visible" },
   };
 
   const content = (
     <>
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,320px)_1fr]">
+      <div className="quiz-layout grid gap-6 lg:grid-cols-[minmax(0,320px)_1fr]">
         <aside className="quiz-sidebar flex w-full flex-col gap-5 rounded-2xl border border-border/60 bg-surface/70 p-5 shadow-sm backdrop-blur-sm">
           <div className="space-y-2">
             <h2 className="text-2xl font-semibold text-white">AscendAI - Gerar Quizzes</h2>
@@ -410,46 +411,43 @@ export default function AscendaIASection({ asModal = false, variant = "standalon
           </div>
         </aside>
 
-        <div className="quiz-main flex-1">
-          <div className="flex h-full flex-col gap-5">
-            {quiz && (
-              <span className="inline-flex w-full items-center justify-center rounded-full border border-emerald-400/40 bg-emerald-400/15 px-3 py-1 text-xs font-medium text-emerald-200 lg:justify-start">
-                Rascunho pronto
-              </span>
-            )}
+        <div className="quiz-main flex flex-col gap-5">
+          {quiz && (
+            <span className="inline-flex w-full items-center justify-center rounded-full border border-emerald-400/40 bg-emerald-400/15 px-3 py-1 text-xs font-medium text-emerald-200 lg:justify-start">
+              Rascunho pronto
+            </span>
+          )}
 
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-white">Níveis do curso</h3>
-              <p className="text-sm text-white/70 whitespace-normal break-words normal-case">
-                Ajuste a seleção de níveis e defina quantas questões deseja gerar para cada etapa do aprendizado.
-              </p>
-            </div>
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold text-white">Níveis do curso</h3>
+            <p className="text-sm text-white/70 whitespace-normal break-words normal-case">
+              Ajuste a seleção de níveis e defina quantas questões deseja gerar para cada etapa do aprendizado.
+            </p>
           </div>
 
-            {/* level cards */}
-            <div className="flex flex-col gap-4 md:flex-row md:flex-wrap md:gap-5">
-              {levels.map((level) => (
-                <div key={level.code} className="w-full md:flex-1">
-                  <LevelCard
-                    color={level.accent}
-                    title={level.title}
-                    desc={level.desc}
-                    checked={Boolean(sel[level.code])}
-                    onToggle={() => handleToggleLevel(level.code)}
-                    value={counts[level.code]}
-                    onChange={(next) => handleCountChange(level.code, next)}
-                  />
-                </div>
-              ))}
-            </div>
-
-            <button
-              type="button"
-              className="mt-5 w-full rounded-2xl border border-dashed border-white/20 bg-transparent px-4 py-3 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/5"
-            >
-              Adicionar novo curso
-            </button>
+          {/* level cards */}
+          <div className="flex flex-col gap-4 md:flex-row md:flex-wrap md:gap-5">
+            {levels.map((level) => (
+              <div key={level.code} className="quiz-card w-full md:min-w-[280px]">
+                <LevelCard
+                  color={level.accent}
+                  title={level.title}
+                  desc={level.desc}
+                  checked={Boolean(sel[level.code])}
+                  onToggle={() => handleToggleLevel(level.code)}
+                  value={counts[level.code]}
+                  onChange={(next) => handleCountChange(level.code, next)}
+                />
+              </div>
+            ))}
           </div>
+
+          <button
+            type="button"
+            className="mt-5 w-full rounded-2xl border border-dashed border-white/20 bg-transparent px-4 py-3 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/5"
+          >
+            Adicionar novo curso
+          </button>
         </div>
       </div>
 

--- a/Ascenda Padrinho att/src/styles/ascenda-quiz-scope.css
+++ b/Ascenda Padrinho att/src/styles/ascenda-quiz-scope.css
@@ -1,58 +1,78 @@
+/* Reset de altura/posição para neutralizar layouts globais */
+[data-quiz-scope] {
+  height: auto !important;
+  min-height: 0 !important;
+  max-height: none !important;
+  overflow: visible !important;
+  position: relative !important;
+}
+
+[data-quiz-scope]::before,
+[data-quiz-scope]::after {
+  content: none !important;
+  display: none !important;
+}
+
 /* Isolamento: neutraliza efeitos do CSS global dentro da aba */
 [data-quiz-scope],
 [data-quiz-scope] * {
   writing-mode: horizontal-tb !important;
   text-orientation: mixed !important;
   rotate: 0deg !important;
-}
-
-/* Evita que textos “estourem” em colunas estreitas */
-[data-quiz-scope] * {
   white-space: normal !important;
   word-break: break-word !important;
   overflow-wrap: anywhere !important;
 }
 
-/* Cards não viram “filetes” */
-[data-quiz-scope] .quiz-card {
-  min-width: 220px;
-  min-height: 200px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-
-/* Impedir scroll horizontal no bloco (sem mascarar bugs visuais) */
-[data-quiz-scope] {
-  overflow-x: hidden;
-}
-
 /* Layout fixo em duas colunas com barra lateral estável */
 [data-quiz-scope] .quiz-layout {
-  display: grid;
-  gap: 1.5rem;
-  align-items: start;
+  display: grid !important;
+  gap: 1.5rem !important;
+  align-items: flex-start !important;
 }
 
-[data-quiz-scope] .quiz-main {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+/* Barra lateral com rolagem isolada */
+[data-quiz-scope] .quiz-sidebar {
+  position: sticky !important;
+  top: 16px !important;
+  max-height: calc(100vh - 32px) !important;
+  overflow-y: auto !important;
+  overscroll-behavior: contain !important;
 }
 
-[data-quiz-scope] .quiz-summary {
-  width: 100%;
-  max-width: 320px;
-  position: relative;
+/* Desativa sticky no mobile */
+@media (max-width: 1024px) {
+  [data-quiz-scope] .quiz-sidebar {
+    position: static !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+}
+
+/* Coluna principal sem alturas forçadas */
+[data-quiz-scope] .quiz-main,
+[data-quiz-scope] .quiz-main > * {
+  height: auto !important;
+  min-height: 0 !important;
+  overflow: visible !important;
+}
+
+/* Cards com altura saudável */
+[data-quiz-scope] .quiz-card {
+  min-width: 220px !important;
+  min-height: 180px !important;
+  height: auto !important;
+}
+
+/* Lista de pré-visualização com rolagem interna controlada */
+[data-quiz-scope] .quiz-preview-list {
+  max-height: 14rem !important;
+  overflow-y: auto !important;
+  padding-right: 0.25rem !important;
 }
 
 @media (min-width: 1024px) {
   [data-quiz-scope] .quiz-layout {
-    grid-template-columns: minmax(0, 1fr) 320px;
-  }
-
-  [data-quiz-scope] .quiz-summary {
-    width: 320px;
+    grid-template-columns: minmax(0, 1fr) 320px !important;
   }
 }


### PR DESCRIPTION
## Summary
- scope quiz layout containers to neutralize inherited height rules and disable pseudo-elements that inflated the page
- rework AscendaIA section markup to drop full-height utilities, add quiz layout hooks, and constrain card/list heights for better scroll behavior
- make the sidebar sticky with its own scroll area on desktop while keeping mobile flow natural

## Testing
- npm run build *(fails: vite not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68eb30bae514832da98d6f09e67e1ca2