### PR TITLE
Add AscendaIA course library workflows

### DIFF
--- a/Ascenda Padrinho att/src/App.jsx
+++ b/Ascenda Padrinho att/src/App.jsx
@@ -8,6 +8,7 @@ import VacationRequests from './pages/VacationRequests.jsx';
 import Reports from './pages/Reports.jsx';
 import AscendaIAQuizzesPage from './pages/AscendaIA/AscendaIAQuizzesPage.jsx';
 import { PAGE_URLS } from './utils/index.js';
+import { useQuizzesStore } from './pages/AscendaIA/stores/useQuizzesStore.js';
 
 const router = createBrowserRouter([
   {
@@ -27,11 +28,19 @@ const router = createBrowserRouter([
         element: <ContentManagement />,
       },
       {
+        path: PAGE_URLS.AscendaIABase.replace(/^\//, ''),
+        element: <Navigate to={PAGE_URLS.AscendaIA} replace />,
+      },
+      {
         path: PAGE_URLS.AscendaIA.replace(/^\//, ''),
         element: <AscendaIAQuizzesPage />,
       },
       {
         path: PAGE_URLS.AscendaIAAssign.replace(/^\//, ''),
+        element: <AscendaIAQuizzesPage />,
+      },
+      {
+        path: PAGE_URLS.AscendaIALibrary.replace(/^\//, ''),
         element: <AscendaIAQuizzesPage />,
       },
       {
@@ -51,6 +60,12 @@ const router = createBrowserRouter([
 ]);
 
 export default function App() {
+  const hydrate = useQuizzesStore((state) => state.hydrate);
+
+  React.useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
   return (
     <RouterProvider
       router={router}

--- a/Ascenda Padrinho att/src/components/feedback/Toaster.jsx
+++ b/Ascenda Padrinho att/src/components/feedback/Toaster.jsx
@@ -20,9 +20,9 @@ export function ToastProvider({ children }) {
   }, []);
 
   const pushToast = React.useCallback(
-    ({ id, title, description, variant = 'default', duration = TOAST_DURATION }) => {
+    ({ id, title, description, variant = 'default', duration = TOAST_DURATION, action = null }) => {
       const toastId = id ?? `toast_${Date.now()}_${Math.round(Math.random() * 1000)}`;
-      setToasts((prev) => [...prev, { id: toastId, title, description, variant, duration }]);
+      setToasts((prev) => [...prev, { id: toastId, title, description, variant, duration, action }]);
 
       if (typeof window !== 'undefined' && duration !== Infinity) {
         window.setTimeout(() => {
@@ -87,10 +87,22 @@ function ToastViewport({ toasts, onDismiss }) {
             )}`}
           >
             <div className="flex items-start gap-3">
-              <div className="flex-1 space-y-1">
+              <div className="flex-1 space-y-2">
                 {toast.title && <p className="text-sm font-semibold">{toast.title}</p>}
                 {toast.description && (
                   <p className="text-xs text-white/70">{toast.description}</p>
+                )}
+                {toast.action && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      toast.action?.onClick?.();
+                      onDismiss(toast.id);
+                    }}
+                    className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-semibold text-white/90 transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+                  >
+                    {toast.action.label}
+                  </button>
                 )}
               </div>
               <button

--- a/Ascenda Padrinho att/src/components/library/AssignFromTemplateModal.jsx
+++ b/Ascenda Padrinho att/src/components/library/AssignFromTemplateModal.jsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useTranslation } from '@/i18n';
+import { useUsersStore } from '@/pages/AscendaIA/stores/useUsersStore';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+
+const VISIBILITY_OPTIONS = [
+  { value: 'Private', translationKey: 'common.private' },
+  { value: 'Team', translationKey: 'common.team' },
+];
+
+export function AssignFromTemplateModal({ template, open, onClose, onAssign }) {
+  const { t } = useTranslation();
+  const { users } = useUsersStore();
+  const interns = React.useMemo(
+    () => users.filter((user) => user.role === 'intern'),
+    [users],
+  );
+
+  const [assignees, setAssignees] = React.useState([]);
+  const [dueDate, setDueDate] = React.useState('');
+  const [visibility, setVisibility] = React.useState('Private');
+
+  React.useEffect(() => {
+    if (open) {
+      setAssignees([]);
+      setDueDate('');
+      setVisibility('Private');
+    }
+  }, [open, template?.id]);
+
+  const toggleAssignee = React.useCallback((login) => {
+    setAssignees((prev) =>
+      prev.includes(login)
+        ? prev.filter((item) => item !== login)
+        : [...prev, login],
+    );
+  }, []);
+
+  const handleSubmit = React.useCallback(() => {
+    if (!template) return;
+    onAssign?.({
+      assignees,
+      dueDate: dueDate || null,
+      visibility,
+    });
+  }, [assignees, dueDate, onAssign, template, visibility]);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-[9998] flex items-center justify-center bg-black/50 px-4 py-10 backdrop-blur"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 16 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.9, y: -10 }}
+            transition={{ type: 'spring', stiffness: 200, damping: 20 }}
+            className="flex w-full max-w-2xl flex-col gap-6 rounded-3xl border border-white/10 bg-surface/95 p-6 shadow-e3"
+          >
+            <header className="space-y-2">
+              <h2 className="text-2xl font-semibold text-white">
+                {t('common.assign_from_template')}
+              </h2>
+              <p className="text-sm text-white/70">{template?.title}</p>
+            </header>
+
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.08em] text-white/60">
+                {t('common.actions.assignTo')}
+              </h3>
+              <div className="grid gap-2 max-h-48 overflow-y-auto pr-2">
+                {interns.map((intern) => (
+                  <label
+                    key={intern.login}
+                    className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/80"
+                  >
+                    <div className="flex flex-col">
+                      <span className="font-medium">{intern.name}</span>
+                      <span className="text-xs text-white/60">{intern.login}</span>
+                    </div>
+                    <Checkbox
+                      checked={assignees.includes(intern.login)}
+                      onCheckedChange={() => toggleAssignee(intern.login)}
+                      aria-label={t('common.actions.assignTo')}
+                    />
+                  </label>
+                ))}
+                {!interns.length && (
+                  <p className="text-sm text-white/60">{t('ascendaQuiz.library.noInterns')}</p>
+                )}
+              </div>
+            </section>
+
+            <section className="grid gap-3">
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-white/80">{t('common.due_date')}</label>
+                <Input type="date" value={dueDate} onChange={(event) => setDueDate(event.target.value)} />
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-white/80">{t('common.visibility')}</label>
+                <Select value={visibility} onValueChange={setVisibility}>
+                  <SelectTrigger className="rounded-2xl border border-white/20 bg-white/5 text-white">
+                    <SelectValue placeholder={t('common.private')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {VISIBILITY_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {t(option.translationKey)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </section>
+
+            <footer className="flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={onClose}
+                className="h-10 rounded-2xl border border-white/10 text-sm text-white hover:bg-white/10"
+              >
+                {t('common.actions.cancel')}
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!assignees.length}
+                className="h-10 rounded-2xl bg-violet-500/80 px-6 text-sm font-semibold text-white hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {t('common.assign')}
+              </Button>
+            </footer>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export default AssignFromTemplateModal;
+

--- a/Ascenda Padrinho att/src/components/library/LibraryGrid.jsx
+++ b/Ascenda Padrinho att/src/components/library/LibraryGrid.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useTranslation } from '@/i18n';
+import { TemplateCard } from './TemplateCard';
+
+export function LibraryGrid({
+  templates,
+  focusId,
+  onEdit,
+  onAssign,
+  onDuplicate,
+  onArchive,
+  emptyMessage,
+}) {
+  const { t } = useTranslation();
+
+  React.useEffect(() => {
+    if (!focusId) return;
+    const element = document.getElementById(`library-card-${focusId}`);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      element.classList.add('ring-2', 'ring-violet-300/60');
+      const timeout = window.setTimeout(() => {
+        element.classList.remove('ring-2', 'ring-violet-300/60');
+      }, 1600);
+      return () => window.clearTimeout(timeout);
+    }
+    return undefined;
+  }, [focusId, templates]);
+
+  if (!templates.length) {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-8 text-center text-sm text-white/70">
+        {emptyMessage ?? t('ascendaQuiz.library.empty')}
+      </div>
+    );
+  }
+
+  return (
+    <AnimatePresence mode="popLayout">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {templates.map((template) => (
+          <motion.div
+            key={template.id}
+            layout
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -12 }}
+            transition={{ duration: 0.2 }}
+            id={`library-card-${template.id}`}
+            className="h-full"
+          >
+            <TemplateCard
+              template={template}
+              onEdit={onEdit}
+              onAssign={onAssign}
+              onDuplicate={onDuplicate}
+              onArchive={onArchive}
+            />
+          </motion.div>
+        ))}
+      </div>
+    </AnimatePresence>
+  );
+}
+

--- a/Ascenda Padrinho att/src/components/library/TemplateCard.jsx
+++ b/Ascenda Padrinho att/src/components/library/TemplateCard.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useTranslation } from '@/i18n';
+import { formatDistanceToNow } from 'date-fns';
+
+function formatRelativeTime(timestamp) {
+  if (!timestamp) return '';
+  try {
+    return formatDistanceToNow(new Date(timestamp), { addSuffix: true });
+  } catch (error) {
+    return '';
+  }
+}
+
+export function TemplateCard({ template, onEdit, onAssign, onDuplicate, onArchive }) {
+  const { t } = useTranslation();
+  const updatedRelative = formatRelativeTime(template.updatedAt);
+
+  return (
+    <motion.article
+      whileHover={{ y: -4, scale: 1.01 }}
+      transition={{ type: 'spring', stiffness: 220, damping: 18 }}
+      className={`flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-surface/80 p-6 shadow-e2 backdrop-blur ${
+        template.archived ? 'opacity-70' : ''
+      }`}
+    >
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="space-y-2">
+            <h3 className="text-lg font-semibold text-white">{template.title}</h3>
+            {template.description && (
+              <p className="text-sm text-white/70 line-clamp-2">{template.description}</p>
+            )}
+          </div>
+          {template.archived && (
+            <Badge variant="outline" className="border-amber-400/60 text-amber-300">
+              {t('common.archived')}
+            </Badge>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 text-xs text-white/60">
+          <Badge className="bg-violet-500/20 text-violet-200">{template.difficulty}</Badge>
+          <Badge variant="outline">v{template.version}</Badge>
+          {updatedRelative && <span>{updatedRelative}</span>}
+        </div>
+
+        {template.tags?.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {template.tags.map((tag) => (
+              <Badge key={tag} className="bg-white/10 text-white/80">
+                #{tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-6 flex flex-wrap gap-2">
+        <Button
+          type="button"
+          onClick={() => onEdit?.(template)}
+          className="h-9 flex-1 rounded-2xl bg-white/90 text-sm font-semibold text-surface hover:brightness-110"
+        >
+          {t('common.edit')}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => onDuplicate?.(template)}
+          className="h-9 flex-1 rounded-2xl border border-white/15 text-sm text-white hover:bg-white/10"
+        >
+          {t('common.duplicate')}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => onAssign?.(template)}
+          className="h-9 flex-1 rounded-2xl border border-emerald-400/30 text-sm text-emerald-200 hover:bg-emerald-400/10"
+        >
+          {t('common.assign')}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => onArchive?.(template, !template.archived)}
+          className="h-9 flex-1 rounded-2xl border border-white/15 text-sm text-white/80 hover:bg-white/10"
+        >
+          {template.archived ? t('common.unarchive') : t('common.archived')}
+        </Button>
+      </div>
+    </motion.article>
+  );
+}
+

--- a/Ascenda Padrinho att/src/components/library/TemplateEditor.jsx
+++ b/Ascenda Padrinho att/src/components/library/TemplateEditor.jsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { useTranslation } from '@/i18n';
+
+function normalizeTags(input) {
+  return input
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+const DIFFICULTY_OPTIONS = [
+  { value: 'Easy', label: 'Easy' },
+  { value: 'Medium', label: 'Medium' },
+  { value: 'Hard', label: 'Hard' },
+];
+
+export function TemplateEditor({ template, open, onClose, onSubmit }) {
+  const { t } = useTranslation();
+  const [title, setTitle] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [tagsInput, setTagsInput] = React.useState('');
+  const [difficulty, setDifficulty] = React.useState('Medium');
+  const [items, setItems] = React.useState([]);
+
+  React.useEffect(() => {
+    if (!template) return;
+    setTitle(template.title ?? '');
+    setDescription(template.description ?? '');
+    setTagsInput((template.tags ?? []).join(', '));
+    setDifficulty(template.difficulty ?? 'Medium');
+    setItems(
+      (template.items ?? []).map((item) => ({
+        id: item.id,
+        question: item.question ?? '',
+        options: Array.isArray(item.options) ? item.options : [],
+        answer: item.answer ?? '',
+      })),
+    );
+  }, [template]);
+
+  const handleItemChange = React.useCallback((index, patch) => {
+    setItems((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], ...patch };
+      return next;
+    });
+  }, []);
+
+  const handleOptionsChange = React.useCallback((index, value) => {
+    const options = value
+      .split('\n')
+      .map((option) => option.trim())
+      .filter(Boolean);
+    handleItemChange(index, { options });
+  }, [handleItemChange]);
+
+  const handleAddItem = React.useCallback(() => {
+    setItems((prev) => [
+      ...prev,
+      {
+        id: `qitm_editor_${Date.now()}_${prev.length}`,
+        question: '',
+        options: [],
+        answer: '',
+      },
+    ]);
+  }, []);
+
+  const handleRemoveItem = React.useCallback((index) => {
+    setItems((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+  }, []);
+
+  const handleSubmit = React.useCallback(() => {
+    if (!template) return;
+    onSubmit?.({
+      title,
+      description,
+      difficulty,
+      tags: normalizeTags(tagsInput),
+      items: items.map((item) => ({
+        id: item.id,
+        question: item.question,
+        options: item.options,
+        answer: item.answer,
+      })),
+    });
+  }, [description, difficulty, items, onSubmit, tagsInput, template, title]);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-[9998] flex items-center justify-center bg-black/40 px-4 py-10 backdrop-blur"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.94, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.9, y: -12 }}
+            transition={{ type: 'spring', stiffness: 220, damping: 22 }}
+            className="relative flex max-h-[90vh] w-full max-w-3xl flex-col gap-6 overflow-y-auto rounded-3xl border border-white/10 bg-surface/95 p-6 shadow-e3"
+          >
+            <header className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-2xl font-semibold text-white">{t('common.edit')}</h2>
+                <p className="text-sm text-white/70">{template?.title}</p>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-full border border-white/10 px-4 py-2 text-sm text-white/70 transition hover:bg-white/10"
+              >
+                {t('common.actions.close')}
+              </button>
+            </header>
+
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-white/80">{t('common.placeholders.courseTitleExample')}</label>
+                <Input value={title} onChange={(event) => setTitle(event.target.value)} />
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-white/80">{t('common.labels.descriptionOptional')}</label>
+                <Textarea
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  rows={3}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-white/80">Tags</label>
+                <Input
+                  value={tagsInput}
+                  onChange={(event) => setTagsInput(event.target.value)}
+                  placeholder="frontend, react, hooks"
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <label className="text-sm font-medium text-white/80">{t('common.filters.level')}</label>
+                <Select value={difficulty} onValueChange={setDifficulty}>
+                  <SelectTrigger className="rounded-2xl border border-white/20 bg-white/5 text-white">
+                    <SelectValue placeholder="Medium" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {DIFFICULTY_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <section className="space-y-4">
+                <header className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold uppercase tracking-[0.08em] text-white/60">
+                    {t('ascendaQuiz.preview.title')}
+                  </h3>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={handleAddItem}
+                    className="h-9 rounded-2xl border border-white/15 text-sm text-white hover:bg-white/10"
+                  >
+                    {t('ascendaQuiz.library.addQuestion')}
+                  </Button>
+                </header>
+
+                <div className="space-y-3">
+                  {items.map((item, index) => (
+                    <div key={item.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <span className="text-xs font-semibold uppercase tracking-[0.08em] text-white/60">
+                          #{index + 1}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveItem(index)}
+                          className="text-xs text-white/60 transition hover:text-white"
+                        >
+                          {t('common.actions.cancel')}
+                        </button>
+                      </div>
+
+                      <div className="mt-3 grid gap-2">
+                        <label className="text-xs font-medium text-white/70">
+                          {t('ascendaQuiz.library.questionLabel')}
+                        </label>
+                        <Textarea
+                          rows={2}
+                          value={item.question}
+                          onChange={(event) => handleItemChange(index, { question: event.target.value })}
+                        />
+                      </div>
+
+                      <div className="mt-3 grid gap-2">
+                        <label className="text-xs font-medium text-white/70">
+                          {t('ascendaQuiz.library.optionsLabel')}
+                        </label>
+                        <Textarea
+                          rows={3}
+                          value={item.options.join('\n')}
+                          onChange={(event) => handleOptionsChange(index, event.target.value)}
+                          placeholder="Option A\nOption B\nOption C"
+                        />
+                      </div>
+
+                      <div className="mt-3 grid gap-2">
+                        <label className="text-xs font-medium text-white/70">
+                          {t('ascendaQuiz.library.answerLabel')}
+                        </label>
+                        <Input
+                          value={item.answer}
+                          onChange={(event) => handleItemChange(index, { answer: event.target.value })}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                  {items.length === 0 && (
+                    <p className="rounded-2xl border border-dashed border-white/10 bg-white/5 p-6 text-center text-sm text-white/60">
+                      {t('ascendaQuiz.library.emptyItems')}
+                    </p>
+                  )}
+                </div>
+              </section>
+            </div>
+
+            <footer className="flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={onClose}
+                className="h-10 rounded-2xl border border-white/10 text-sm text-white hover:bg-white/10"
+              >
+                {t('common.actions.cancel')}
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                className="h-10 rounded-2xl bg-emerald-500/80 px-6 text-sm font-semibold text-emerald-950 hover:brightness-110"
+              >
+                {t('common.actions.saveChanges')}
+              </Button>
+            </footer>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export default TemplateEditor;
+

--- a/Ascenda Padrinho att/src/i18n/en.json
+++ b/Ascenda Padrinho att/src/i18n/en.json
@@ -4,6 +4,21 @@
     "managerPortal": "Manager Portal",
     "navigation": "Navigation",
     "manager": "Manager",
+    "course_library": "Course Library",
+    "assign_from_template": "Assign from Template",
+    "new_version_saved": "New version saved",
+    "saved_to_library": "Saved to Library",
+    "archived": "Archived",
+    "unarchive": "Unarchive",
+    "duplicate": "Duplicate",
+    "preview": "Preview",
+    "edit": "Edit",
+    "assign": "Assign",
+    "due_date": "Due date",
+    "visibility": "Visibility",
+    "private": "Private",
+    "team": "Team",
+    "assigned_to_you": "New quiz assigned to you",
     "actions": {
       "logout": "Logout",
       "cancel": "Cancel",
@@ -436,6 +451,27 @@
       "backNote": "Need to attach quizzes back to a course? Return to the content dashboard when you are ready.",
       "backCta": "Back to content management"
     },
+    "library": {
+      "subtitle": "Curate generated quizzes and reuse them with a single assign action.",
+      "empty": "No templates yet. Generate new ones in AscendaIA → Generator.",
+      "searchLabel": "Search",
+      "searchPlaceholder": "Search by title, tags or description",
+      "difficultyFilter": "Difficulty",
+      "tagsFilter": "Filter by tags",
+      "noTags": "No tags yet",
+      "showArchived": "Show archived",
+      "addQuestion": "Add question",
+      "questionLabel": "Question prompt",
+      "optionsLabel": "Options (one per line)",
+      "answerLabel": "Correct answer",
+      "emptyItems": "No questions yet. Add items to this template.",
+      "noInterns": "No interns available.",
+      "assignError": "We couldn’t assign the template.",
+      "confirmArchive": "Archive template \"{{title}}\"? It will stay hidden until you undo."
+    },
+    "generator": {
+      "autoSavedToLibrary": "Quiz automatically saved to the library."
+    },
     "form": {
       "title": "Content sources",
       "subtitle": "Combine topics, videos or text files to feed the generator.",
@@ -498,13 +534,20 @@
         "challengeN": "Challenge {{n}}: exploring advanced insights on {{topic}}."
       }
     },
+    "tabs": {
+      "generator": "Generator",
+      "assign": "Assign Quizzes",
+      "library": "Library"
+    },
     "actions": {
       "discard": "Discard",
       "save": "Save quiz",
       "saved": "Quiz saved locally!",
       "saveError": "Unable to save the quiz locally.",
       "reviewBeforeSaving": "Review the generated content before saving.",
-      "generateToEnable": "Generate a quiz to enable saving options."
+      "generateToEnable": "Generate a quiz to enable saving options.",
+      "saveTemplate": "Save as template",
+      "openLibrary": "Open in library"
     },
     "feedback": {
       "generationError": "Something went wrong while generating the quiz. Try again."
@@ -518,6 +561,14 @@
       "decrease": "Decrease {{level}}",
       "toggle": "Enable {{level}} level",
       "itemsField": "Items for {{level}}"
+    },
+    "assign": {
+      "libraryList": {
+        "title": "Library templates",
+        "subtitle": "Select one or more saved templates to assign.",
+        "count": "{{count}} available",
+        "empty": "No templates available in the library."
+      }
     }
   }
 }

--- a/Ascenda Padrinho att/src/i18n/pt.json
+++ b/Ascenda Padrinho att/src/i18n/pt.json
@@ -4,6 +4,21 @@
     "managerPortal": "Portal do Gestor",
     "navigation": "Navegação",
     "manager": "Gestor",
+    "course_library": "Biblioteca de Cursos",
+    "assign_from_template": "Designar do Template",
+    "new_version_saved": "Nova versão salva",
+    "saved_to_library": "Salvo na Biblioteca",
+    "archived": "Arquivado",
+    "unarchive": "Desarquivar",
+    "duplicate": "Duplicar",
+    "preview": "Pré-visualizar",
+    "edit": "Editar",
+    "assign": "Designar",
+    "due_date": "Prazo",
+    "visibility": "Visibilidade",
+    "private": "Privado",
+    "team": "Time",
+    "assigned_to_you": "Novo quiz designado para você",
     "actions": {
       "logout": "Sair",
       "cancel": "Cancelar",
@@ -436,6 +451,27 @@
       "backNote": "Precisa anexar os quizzes a um curso? Volte ao painel de conteúdo quando estiver pronto.",
       "backCta": "Voltar para gestão de conteúdo"
     },
+    "library": {
+      "subtitle": "Curadoria dos quizzes gerados para reaproveitar e atribuir com um clique.",
+      "empty": "Nenhum template ainda. Gere no AscendaIA → Generator.",
+      "searchLabel": "Buscar",
+      "searchPlaceholder": "Busque por título, tags ou descrição",
+      "difficultyFilter": "Dificuldade",
+      "tagsFilter": "Filtrar por tags",
+      "noTags": "Sem tags ainda",
+      "showArchived": "Mostrar arquivados",
+      "addQuestion": "Adicionar questão",
+      "questionLabel": "Enunciado da pergunta",
+      "optionsLabel": "Opções (uma por linha)",
+      "answerLabel": "Resposta correta",
+      "emptyItems": "Nenhuma questão cadastrada. Adicione perguntas para este template.",
+      "noInterns": "Nenhum estagiário disponível.",
+      "assignError": "Não foi possível designar o template.",
+      "confirmArchive": "Arquivar o template \"{{title}}\"? Ele ficará oculto até você desfazer."
+    },
+    "generator": {
+      "autoSavedToLibrary": "Quiz salvo automaticamente na biblioteca."
+    },
     "form": {
       "title": "Fontes de conteúdo",
       "subtitle": "Combine temas, vídeos ou arquivos de texto para alimentar o gerador.",
@@ -498,13 +534,20 @@
         "challengeN": "Desafio {{n}}: explorando conceitos avançados de {{topic}}."
       }
     },
+    "tabs": {
+      "generator": "Gerador",
+      "assign": "Designar Quizzes",
+      "library": "Biblioteca"
+    },
     "actions": {
       "discard": "Descartar",
       "save": "Salvar quiz",
       "saved": "Quiz salvo localmente!",
       "saveError": "Não foi possível salvar o quiz localmente.",
       "reviewBeforeSaving": "Revise o conteúdo gerado antes de salvar.",
-      "generateToEnable": "Gere um quiz para liberar as opções de salvamento."
+      "generateToEnable": "Gere um quiz para liberar as opções de salvamento.",
+      "saveTemplate": "Salvar como template",
+      "openLibrary": "Abrir na biblioteca"
     },
     "feedback": {
       "generationError": "Algo deu errado ao gerar o quiz. Tente novamente."
@@ -518,6 +561,14 @@
       "decrease": "Reduzir {{level}}",
       "toggle": "Ativar nível {{level}}",
       "itemsField": "Itens para {{level}}"
+    },
+    "assign": {
+      "libraryList": {
+        "title": "Templates da biblioteca",
+        "subtitle": "Selecione 1 ou mais templates salvos para atribuir.",
+        "count": "{{count}} disponíveis",
+        "empty": "Nenhum template disponível na biblioteca."
+      }
     }
   }
 }

--- a/Ascenda Padrinho att/src/lib/localforage.js
+++ b/Ascenda Padrinho att/src/lib/localforage.js
@@ -1,0 +1,49 @@
+const isBrowser = typeof window !== 'undefined';
+
+function makeKey(prefix, key) {
+  return `${prefix}${key}`;
+}
+
+function createAdapter(prefix = '') {
+  const storage = isBrowser ? window.localStorage : null;
+
+  return {
+    async getItem(key) {
+      if (!storage) return null;
+      try {
+        const value = storage.getItem(makeKey(prefix, key));
+        return value ? JSON.parse(value) : null;
+      } catch (error) {
+        console.error('localforage shim getItem failed', error);
+        return null;
+      }
+    },
+
+    async setItem(key, value) {
+      if (!storage) return value;
+      try {
+        storage.setItem(makeKey(prefix, key), JSON.stringify(value));
+      } catch (error) {
+        console.error('localforage shim setItem failed', error);
+      }
+      return value;
+    },
+
+    async removeItem(key) {
+      if (!storage) return null;
+      storage.removeItem(makeKey(prefix, key));
+      return null;
+    },
+  };
+}
+
+const defaultInstance = createAdapter('');
+
+export default {
+  createInstance({ name } = {}) {
+    const prefix = name ? `${name}:` : '';
+    return createAdapter(prefix);
+  },
+  ...defaultInstance,
+};
+

--- a/Ascenda Padrinho att/src/pages/AscendaIA/AscendaIAQuizzesPage.jsx
+++ b/Ascenda Padrinho att/src/pages/AscendaIA/AscendaIAQuizzesPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Sparkles } from 'lucide-react';
 import { useTranslation } from '@/i18n';
 import { useAscendaIAQuizGen } from './hooks/useAscendaIAQuizGen';
@@ -12,8 +12,30 @@ import { SaveDraftBar } from './components/SaveDraftBar';
 import { Button } from '@/components/ui/button';
 import { PAGE_URLS } from '@/utils';
 import { LanguageSwitcher } from './components/LanguageSwitcher';
+import AssignQuizzesPanel from './AssignQuizzesPanel';
+import CourseLibrary from './CourseLibrary.jsx';
+import { useQuizzesStore } from './stores/useQuizzesStore';
+import { useToast } from '@/components/feedback/Toaster';
 
 import './styles/ascenda-quizz.css';
+
+const QUIZ_LEVELS_KEYS = ['easy', 'intermediate', 'advanced'];
+
+function flattenQuizItems(quiz) {
+  if (!quiz) return [];
+  return QUIZ_LEVELS_KEYS.flatMap((level) =>
+    (quiz?.[level] ?? []).map((item) => ({
+      id: item.id,
+      question: item.prompt ?? '',
+      options: item.options ?? [],
+      answer:
+        typeof item.correctIndex === 'number'
+          ? item.options?.[item.correctIndex] ?? ''
+          : item.answer ?? '',
+      level,
+    })),
+  );
+}
 
 export default function AscendaIAQuizzesPage() {
   const {
@@ -44,31 +66,56 @@ export default function AscendaIAQuizzesPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+  const { pushToast } = useToast();
 
-  const basePath = PAGE_URLS.AscendaIA;
-  const assignPath = PAGE_URLS.AscendaIAAssign;
-  const isAssignRoute = location.pathname.startsWith(assignPath);
-  const [activeTab, setActiveTab] = React.useState(isAssignRoute ? 'assign' : 'generator');
+  const addTemplateFromGenerator = useQuizzesStore((state) => state.addTemplateFromGenerator);
+  const updateTemplate = useQuizzesStore((state) => state.updateTemplate);
 
-  React.useEffect(() => {
-    setActiveTab(isAssignRoute ? 'assign' : 'generator');
-  }, [isAssignRoute]);
+  const [lastTemplateId, setLastTemplateId] = React.useState(null);
+
+  const activeTab = React.useMemo(() => {
+    if (location.pathname.startsWith(PAGE_URLS.AscendaIALibrary)) return 'library';
+    if (location.pathname.startsWith(PAGE_URLS.AscendaIAAssign)) return 'assign';
+    return 'generator';
+  }, [location.pathname]);
+
+  const focusParam = React.useMemo(() => {
+    if (!location.search) return null;
+    return new URLSearchParams(location.search).get('focus');
+  }, [location.search]);
+
+  const tabs = React.useMemo(
+    () => [
+      { key: 'generator', label: t('ascendaQuiz.tabs.generator'), path: PAGE_URLS.AscendaIA },
+      { key: 'assign', label: t('ascendaQuiz.tabs.assign'), path: PAGE_URLS.AscendaIAAssign },
+      { key: 'library', label: t('common.course_library'), path: PAGE_URLS.AscendaIALibrary },
+    ],
+    [t],
+  );
 
   const handleTabChange = React.useCallback(
     (next) => {
-      setActiveTab(next);
-      if (next === 'assign') {
-        if (!location.pathname.startsWith(assignPath)) {
-          navigate(assignPath);
-        }
-      } else if (location.pathname !== basePath) {
-        navigate(basePath);
-      }
+      const tab = tabs.find((item) => item.key === next);
+      if (!tab) return;
+      navigate(tab.path);
     },
-    [assignPath, basePath, location.pathname, navigate],
+    [navigate, tabs],
   );
 
-  const handleSave = React.useCallback(() => {
+  const handleGenerate = React.useCallback(async () => {
+    const result = await generate();
+    if (!result) return;
+
+    const template = addTemplateFromGenerator({ quiz: result });
+    setLastTemplateId(template.id);
+    pushToast({
+      variant: 'success',
+      title: t('common.saved_to_library'),
+      description: t('ascendaQuiz.generator.autoSavedToLibrary'),
+    });
+  }, [addTemplateFromGenerator, generate, pushToast, t]);
+
+  const handleSaveDraft = React.useCallback(() => {
     if (!quiz) return;
     const success = saveDraft();
     window.alert(success ? t('ascendaQuiz.actions.saved') : t('ascendaQuiz.actions.saveError'));
@@ -78,6 +125,53 @@ export default function AscendaIAQuizzesPage() {
     discard();
     setFeedback('');
   }, [discard, setFeedback]);
+
+  const handleSaveTemplate = React.useCallback(() => {
+    if (!quiz) return;
+
+    const payload = {
+      title: quiz.topic,
+      description: quiz.source,
+      items: flattenQuizItems(quiz),
+    };
+
+    const updated = lastTemplateId
+      ? updateTemplate(lastTemplateId, payload)
+      : addTemplateFromGenerator({ quiz }, payload);
+
+    const templateId = updated?.id ?? lastTemplateId;
+    if (updated?.id && updated.id !== lastTemplateId) {
+      setLastTemplateId(updated.id);
+    }
+
+    pushToast({
+      variant: 'success',
+      title: t('common.new_version_saved'),
+      description: t('common.saved_to_library'),
+    });
+
+    return templateId;
+  }, [addTemplateFromGenerator, lastTemplateId, pushToast, quiz, t, updateTemplate]);
+
+  const handleOpenLibrary = React.useCallback(() => {
+    if (!lastTemplateId) {
+      navigate(PAGE_URLS.AscendaIALibrary);
+      return;
+    }
+    navigate(`${PAGE_URLS.AscendaIALibrary}?focus=${encodeURIComponent(lastTemplateId)}`);
+  }, [lastTemplateId, navigate]);
+
+  const headerTitle = React.useMemo(() => {
+    if (activeTab === 'assign') return t('ascendaQuiz.assign.title');
+    if (activeTab === 'library') return t('common.course_library');
+    return t('ascendaQuiz.page.title');
+  }, [activeTab, t]);
+
+  const headerSubtitle = React.useMemo(() => {
+    if (activeTab === 'assign') return t('ascendaQuiz.assign.subtitle');
+    if (activeTab === 'library') return t('ascendaQuiz.library.subtitle');
+    return t('ascendaQuiz.page.subtitle');
+  }, [activeTab, t]);
 
   return (
     <main data-quiz-scope className="min-h-screen bg-surface/30 py-10">
@@ -105,72 +199,100 @@ export default function AscendaIAQuizzesPage() {
             <LanguageSwitcher />
           </div>
 
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between lg:gap-6">
-            <div className="space-y-2">
-              <h1 className="text-3xl font-semibold text-white lg:text-4xl">
-                {t('ascendaQuiz.page.title')}
-              </h1>
-              <p className="max-w-2xl text-sm text-white/70">
-                {t('ascendaQuiz.page.subtitle')}
-              </p>
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between lg:gap-6">
+              <div className="space-y-2">
+                <h1 className="text-3xl font-semibold text-white lg:text-4xl">{headerTitle}</h1>
+                <p className="max-w-2xl text-sm text-white/70">{headerSubtitle}</p>
+              </div>
+              <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+                <Sparkles className="h-5 w-5 text-white" aria-hidden="true" />
+                <span>{t('ascendaQuiz.page.powered')}</span>
+              </div>
             </div>
-            <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
-              <Sparkles className="h-5 w-5 text-white" aria-hidden="true" />
-              <span>{t('ascendaQuiz.page.powered')}</span>
-            </div>
+
+            <nav className="flex flex-wrap gap-2">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => handleTabChange(tab.key)}
+                  className={`rounded-full px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 ${
+                    activeTab === tab.key
+                      ? 'bg-white text-surface'
+                      : 'border border-white/20 bg-white/5 text-white/70 hover:bg-white/10'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </nav>
           </div>
         </motion.header>
 
-        <section className="layout grid gap-6 lg:gap-8 xl:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
-          <div className="flex flex-col gap-6 lg:gap-8">
-            <SourceInputPanel
-              topic={topic}
-              setTopic={setTopic}
-              youtubeUrl={youtubeUrl}
-              setYoutubeUrl={setYoutubeUrl}
-              textFile={textFile}
-              setTextFile={setTextFile}
-              errors={errors}
-              setErrors={setErrors}
-              onClearTextFile={clearTextFile}
-              youtubeValid={youtubeValid}
+        {activeTab === 'generator' && (
+          <>
+            <section className="layout grid gap-6 lg:gap-8 xl:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
+              <div className="flex flex-col gap-6 lg:gap-8">
+                <SourceInputPanel
+                  topic={topic}
+                  setTopic={setTopic}
+                  youtubeUrl={youtubeUrl}
+                  setYoutubeUrl={setYoutubeUrl}
+                  textFile={textFile}
+                  setTextFile={setTextFile}
+                  errors={errors}
+                  setErrors={setErrors}
+                  onClearTextFile={clearTextFile}
+                  youtubeValid={youtubeValid}
+                />
+
+                <SummaryPanel
+                  levels={levels}
+                  setLevelEnabled={setLevelEnabled}
+                  setLevelCount={setLevelCount}
+                  totalRequested={totalRequested}
+                  canGenerate={canGenerate}
+                  loading={loading}
+                  onGenerate={handleGenerate}
+                  feedback={feedback}
+                />
+              </div>
+
+              <div className="flex flex-col gap-6 lg:gap-8">
+                <QuizLevelsPanel
+                  levels={levels}
+                  setLevelEnabled={setLevelEnabled}
+                  setLevelCount={setLevelCount}
+                />
+                <PreviewPanel quiz={quiz} />
+              </div>
+            </section>
+
+            <SaveDraftBar
+              quiz={quiz}
+              onDiscard={handleDiscard}
+              onSave={handleSaveDraft}
+              onSaveTemplate={handleSaveTemplate}
+              onOpenLibrary={handleOpenLibrary}
             />
 
-            <SummaryPanel
-              levels={levels}
-              setLevelEnabled={setLevelEnabled}
-              setLevelCount={setLevelCount}
-              totalRequested={totalRequested}
-              canGenerate={canGenerate}
-              loading={loading}
-              onGenerate={generate}
-              feedback={feedback}
-            />
-          </div>
+            <div className="rounded-2xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm lg:p-8">
+              <p className="text-sm text-white/70">{t('ascendaQuiz.page.backNote')}</p>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => navigate(PAGE_URLS.ContentManagement)}
+                className="mt-3 h-11 rounded-xl border border-white/10 bg-transparent text-sm font-semibold text-white transition hover:bg-white/10"
+              >
+                {t('ascendaQuiz.page.backCta')}
+              </Button>
+            </div>
+          </>
+        )}
 
-          <div className="flex flex-col gap-6 lg:gap-8">
-            <QuizLevelsPanel
-              levels={levels}
-              setLevelEnabled={setLevelEnabled}
-              setLevelCount={setLevelCount}
-            />
-            <PreviewPanel quiz={quiz} />
-          </div>
-        </section>
-
-        <SaveDraftBar quiz={quiz} onDiscard={handleDiscard} onSave={handleSave} />
-
-        <div className="rounded-2xl border border-border/60 bg-surface/80 p-6 shadow-e1 backdrop-blur-sm lg:p-8">
-          <p className="text-sm text-white/70">{t('ascendaQuiz.page.backNote')}</p>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => navigate(PAGE_URLS.ContentManagement)}
-            className="mt-3 h-11 rounded-xl border border-white/10 bg-transparent text-sm font-semibold text-white transition hover:bg-white/10"
-          >
-            {t('ascendaQuiz.page.backCta')}
-          </Button>
-        </div>
+        {activeTab === 'assign' && <AssignQuizzesPanel />}
+        {activeTab === 'library' && <CourseLibrary focusId={focusParam} />}
       </div>
     </main>
   );

--- a/Ascenda Padrinho att/src/pages/AscendaIA/CourseLibrary.jsx
+++ b/Ascenda Padrinho att/src/pages/AscendaIA/CourseLibrary.jsx
@@ -1,0 +1,278 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { useTranslation } from '@/i18n';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { LibraryGrid } from '@/components/library/LibraryGrid';
+import TemplateEditor from '@/components/library/TemplateEditor';
+import AssignFromTemplateModal from '@/components/library/AssignFromTemplateModal';
+import { useQuizzesStore } from './stores/useQuizzesStore';
+import { useToast } from '@/components/feedback/Toaster';
+
+const DIFFICULTY_FILTERS = [
+  { value: 'all', label: 'All' },
+  { value: 'Easy', label: 'Easy' },
+  { value: 'Medium', label: 'Medium' },
+  { value: 'Hard', label: 'Hard' },
+];
+
+function normalizeText(text) {
+  return (text ?? '').toLowerCase();
+}
+
+export default function CourseLibrary({ focusId }) {
+  const { t } = useTranslation();
+  const templates = useQuizzesStore((state) => state.templates);
+  const updateTemplate = useQuizzesStore((state) => state.updateTemplate);
+  const duplicateTemplate = useQuizzesStore((state) => state.duplicateTemplate);
+  const archiveTemplate = useQuizzesStore((state) => state.archiveTemplate);
+  const assignFromTemplate = useQuizzesStore((state) => state.assignFromTemplate);
+  const { pushToast } = useToast();
+
+  const [searchTerm, setSearchTerm] = React.useState('');
+  const [selectedTags, setSelectedTags] = React.useState([]);
+  const [difficultyFilter, setDifficultyFilter] = React.useState('all');
+  const [showArchived, setShowArchived] = React.useState(false);
+  const [editingTemplate, setEditingTemplate] = React.useState(null);
+  const [assigningTemplate, setAssigningTemplate] = React.useState(null);
+  const [focus, setFocus] = React.useState(focusId ?? null);
+
+  React.useEffect(() => {
+    if (focusId) {
+      setFocus(focusId);
+    }
+  }, [focusId, templates.length]);
+
+  const allTags = React.useMemo(() => {
+    const tagSet = new Set();
+    templates.forEach((template) => {
+      (template.tags ?? []).forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
+  }, [templates]);
+
+  const filteredTemplates = React.useMemo(() => {
+    return templates.filter((template) => {
+      if (!showArchived && template.archived) return false;
+
+      if (difficultyFilter !== 'all' && template.difficulty !== difficultyFilter) {
+        return false;
+      }
+
+      if (selectedTags.length) {
+        const templateTags = template.tags ?? [];
+        const matchesAll = selectedTags.every((tag) => templateTags.includes(tag));
+        if (!matchesAll) return false;
+      }
+
+      if (searchTerm.trim()) {
+        const term = normalizeText(searchTerm);
+        const haystack = [template.title, template.description, ...(template.tags ?? [])]
+          .map(normalizeText)
+          .join(' ');
+        if (!haystack.includes(term)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [difficultyFilter, searchTerm, selectedTags, showArchived, templates]);
+
+  const toggleTag = React.useCallback((tag) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((item) => item !== tag) : [...prev, tag],
+    );
+  }, []);
+
+  const handleDuplicate = React.useCallback(
+    (template) => {
+      const copy = duplicateTemplate(template.id);
+      if (copy) {
+        pushToast({
+          variant: 'success',
+          title: t('common.duplicate'),
+          description: copy.title,
+        });
+        setFocus(copy.id);
+      }
+    },
+    [duplicateTemplate, pushToast, t],
+  );
+
+  const handleArchive = React.useCallback(
+    (template, archive) => {
+      if (archive) {
+        const confirmed = window.confirm(
+          t('ascendaQuiz.library.confirmArchive', { title: template.title }),
+        );
+        if (!confirmed) return;
+      }
+
+      const updated = archiveTemplate(template.id, archive);
+      if (!updated) return;
+
+      pushToast({
+        variant: archive ? 'default' : 'success',
+        title: archive ? t('common.archived') : t('common.unarchive'),
+        description: template.title,
+        duration: archive ? 5000 : undefined,
+        action: archive
+          ? {
+              label: t('common.unarchive'),
+              onClick: () => archiveTemplate(template.id, false),
+            }
+          : undefined,
+      });
+    },
+    [archiveTemplate, pushToast, t],
+  );
+
+  const handleEditSubmit = React.useCallback(
+    (payload) => {
+      if (!editingTemplate) return;
+      const updated = updateTemplate(editingTemplate.id, payload);
+      if (updated) {
+        pushToast({
+          variant: 'success',
+          title: t('common.new_version_saved'),
+          description: updated.title,
+        });
+      }
+      setEditingTemplate(null);
+    },
+    [editingTemplate, pushToast, t, updateTemplate],
+  );
+
+  const handleAssign = React.useCallback(
+    ({ assignees, dueDate, visibility }) => {
+      if (!assigningTemplate) return;
+      try {
+        const assignment = assignFromTemplate(assigningTemplate.id, {
+          assignees,
+          dueDate,
+          visibility,
+        });
+        pushToast({
+          variant: 'success',
+          title: t('common.assign_from_template'),
+          description: `${assigningTemplate.title} • ${assignees.length} ${t('common.status.assigned').toLowerCase()}`,
+        });
+        setAssigningTemplate(null);
+        setFocus(assigningTemplate.id);
+        return assignment;
+      } catch (error) {
+        pushToast({
+          variant: 'error',
+          title: t('ascendaQuiz.library.assignError'),
+          description: error.message,
+        });
+      }
+      return null;
+    },
+    [assignFromTemplate, assigningTemplate, pushToast, t],
+  );
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25 }}
+      className="flex flex-col gap-6"
+    >
+      <div className="rounded-3xl border border-white/10 bg-surface/80 p-6 shadow-e2 backdrop-blur">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="grid gap-2">
+            <label className="text-xs font-semibold uppercase tracking-[0.08em] text-white/60">
+              {t('ascendaQuiz.library.searchLabel')}
+            </label>
+            <Input
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder={t('ascendaQuiz.library.searchPlaceholder')}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <label className="text-xs font-semibold uppercase tracking-[0.08em] text-white/60">
+              {t('ascendaQuiz.library.difficultyFilter')}
+            </label>
+            <Select value={difficultyFilter} onValueChange={setDifficultyFilter}>
+              <SelectTrigger className="rounded-2xl border border-white/20 bg-white/5 text-white">
+                <SelectValue placeholder="All" />
+              </SelectTrigger>
+              <SelectContent>
+                {DIFFICULTY_FILTERS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2 md:col-span-2">
+            <label className="text-xs font-semibold uppercase tracking-[0.08em] text-white/60">
+              {t('ascendaQuiz.library.tagsFilter')}
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {allTags.map((tag) => {
+                const active = selectedTags.includes(tag);
+                return (
+                  <Button
+                    key={tag}
+                    type="button"
+                    variant="ghost"
+                    onClick={() => toggleTag(tag)}
+                    className={`h-8 rounded-full border px-3 text-xs transition ${
+                      active
+                        ? 'border-violet-400 bg-violet-500/20 text-violet-100'
+                        : 'border-white/15 bg-white/5 text-white/70 hover:bg-white/10'
+                    }`}
+                  >
+                    #{tag}
+                  </Button>
+                );
+              })}
+              {!allTags.length && (
+                <span className="text-xs text-white/50">{t('ascendaQuiz.library.noTags')}</span>
+              )}
+            </div>
+          </div>
+
+          <label className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+            <Checkbox checked={showArchived} onCheckedChange={(value) => setShowArchived(Boolean(value))} />
+            <span>{t('ascendaQuiz.library.showArchived')}</span>
+          </label>
+        </div>
+      </div>
+
+      <LibraryGrid
+        templates={filteredTemplates}
+        focusId={focus}
+        onEdit={(template) => setEditingTemplate(template)}
+        onAssign={(template) => setAssigningTemplate(template)}
+        onDuplicate={handleDuplicate}
+        onArchive={handleArchive}
+        emptyMessage={t('ascendaQuiz.library.empty')}
+      />
+
+      <TemplateEditor
+        open={Boolean(editingTemplate)}
+        template={editingTemplate}
+        onClose={() => setEditingTemplate(null)}
+        onSubmit={handleEditSubmit}
+      />
+
+      <AssignFromTemplateModal
+        open={Boolean(assigningTemplate)}
+        template={assigningTemplate}
+        onClose={() => setAssigningTemplate(null)}
+        onAssign={handleAssign}
+      />
+    </motion.section>
+  );
+}
+

--- a/Ascenda Padrinho att/src/pages/AscendaIA/components/SaveDraftBar.jsx
+++ b/Ascenda Padrinho att/src/pages/AscendaIA/components/SaveDraftBar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from '@/i18n';
 import { Button } from '@/components/ui/button';
 
-export function SaveDraftBar({ quiz, onDiscard, onSave }) {
+export function SaveDraftBar({ quiz, onDiscard, onSave, onSaveTemplate, onOpenLibrary }) {
   const { t } = useTranslation();
 
   return (
@@ -26,6 +26,22 @@ export function SaveDraftBar({ quiz, onDiscard, onSave }) {
           className="h-10 rounded-xl bg-emerald-500/80 text-sm font-semibold text-emerald-950 transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {t('ascendaQuiz.actions.save')}
+        </Button>
+        <Button
+          type="button"
+          onClick={() => quiz && onSaveTemplate?.()}
+          disabled={!quiz}
+          className="h-10 rounded-xl bg-violet-500/80 text-sm font-semibold text-white transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {t('ascendaQuiz.actions.saveTemplate')}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onOpenLibrary}
+          className="h-10 rounded-xl border border-white/20 bg-transparent text-sm font-semibold text-white transition hover:bg-white/10"
+        >
+          {t('ascendaQuiz.actions.openLibrary')}
         </Button>
       </div>
     </div>

--- a/Ascenda Padrinho att/src/pages/AscendaIA/hooks/useAscendaIAQuizGen.js
+++ b/Ascenda Padrinho att/src/pages/AscendaIA/hooks/useAscendaIAQuizGen.js
@@ -154,7 +154,7 @@ export function useAscendaIAQuizGen() {
   const generate = useCallback(async () => {
     if (!canGenerate || !resolvedSource) {
       setFeedback('ascendaQuiz.form.errors.sourceRequired');
-      return;
+      return null;
     }
 
     const payload = {
@@ -166,7 +166,7 @@ export function useAscendaIAQuizGen() {
 
     if (Object.values(payload.counts).every((count) => count === 0)) {
       setFeedback('ascendaQuiz.form.errors.sourceRequired');
-      return;
+      return null;
     }
 
     setLoading(true);
@@ -176,12 +176,15 @@ export function useAscendaIAQuizGen() {
     try {
       const result = await ascendaIAClient.generateQuizzes(payload);
       setQuiz(result);
+      return result;
     } catch (error) {
       console.error('AscendaIA generation failed', error);
       setFeedback('ascendaQuiz.feedback.generationError');
+      return null;
     } finally {
       setLoading(false);
     }
+    return null;
   }, [buildCounts, canGenerate, normalizeTopic, resolvedSource]);
 
   const discard = useCallback(() => {

--- a/Ascenda Padrinho att/src/pages/AscendaIA/services/quiz.service.mock.js
+++ b/Ascenda Padrinho att/src/pages/AscendaIA/services/quiz.service.mock.js
@@ -1,13 +1,57 @@
 import { MOCK_GENERATED_QUIZZES } from '../mocks/quizzes.mock';
+import { useQuizzesStore } from '../stores/useQuizzesStore';
 
 const simulateDelay = (result, delay = 240) =>
   new Promise((resolve) => setTimeout(() => resolve(result), delay));
+
+const getStore = () => useQuizzesStore.getState();
 
 export const QuizService = {
   async listGenerated() {
     return simulateDelay(MOCK_GENERATED_QUIZZES);
   },
-  async assign(assignments) {
-    return simulateDelay({ success: true, assignments }, 200);
+
+  async listTemplates() {
+    return simulateDelay(getStore().templates);
+  },
+
+  async createTemplate(payload) {
+    const template = getStore().addTemplateFromGenerator(payload);
+    return simulateDelay(template);
+  },
+
+  async updateTemplate(id, patch) {
+    const template = getStore().updateTemplate(id, patch);
+    return simulateDelay(template);
+  },
+
+  async duplicateTemplate(id) {
+    const template = getStore().duplicateTemplate(id);
+    return simulateDelay(template);
+  },
+
+  async archiveTemplate(id, flag = true) {
+    const template = getStore().archiveTemplate(id, flag);
+    return simulateDelay(template);
+  },
+
+  async assignFromTemplate(templateId, payload) {
+    try {
+      const assignment = getStore().assignFromTemplate(templateId, payload);
+      return simulateDelay({ success: true, assignmentIds: [assignment.id] });
+    } catch (error) {
+      console.error('assignFromTemplate failed', error);
+      return simulateDelay({ success: false, message: error.message ?? 'assignment failed' });
+    }
+  },
+
+  async listInbox(userId) {
+    const inbox = getStore().inboxByUser[userId] ?? [];
+    return simulateDelay(inbox);
+  },
+
+  async markDone(userId, quizId) {
+    const quiz = getStore().markQuizDone(userId, quizId);
+    return simulateDelay({ success: Boolean(quiz), quiz });
   },
 };

--- a/Ascenda Padrinho att/src/pages/AscendaIA/stores/useQuizzesStore.js
+++ b/Ascenda Padrinho att/src/pages/AscendaIA/stores/useQuizzesStore.js
@@ -1,26 +1,387 @@
 import { create } from 'zustand';
+import localforage from '@/lib/localforage';
+import { nanoid } from 'nanoid';
+
+const STORAGE_KEYS = {
+  templates: 'afq:templates',
+  assignments: 'afq:assignments',
+  inboxIndex: 'afq:inbox:index',
+  inboxFor: (userId) => `afq:inbox:${userId}`,
+};
+
+const storage = localforage.createInstance({ name: 'ascenda-ia' });
+
+const debounceTimers = new Map();
+const DEBOUNCE_MS = 300;
+
+function schedulePersist(key, value) {
+  const existing = debounceTimers.get(key);
+  if (existing) {
+    clearTimeout(existing);
+  }
+
+  const timer = setTimeout(() => {
+    storage.setItem(key, value).catch((error) => {
+      console.error(`Failed to persist key "${key}"`, error);
+    });
+    debounceTimers.delete(key);
+  }, DEBOUNCE_MS);
+
+  debounceTimers.set(key, timer);
+}
+
+async function loadInboxFromStorage() {
+  try {
+    const index = (await storage.getItem(STORAGE_KEYS.inboxIndex)) ?? [];
+    if (!Array.isArray(index) || !index.length) {
+      return {};
+    }
+
+    const entries = await Promise.all(
+      index.map(async (userId) => {
+        const list = (await storage.getItem(STORAGE_KEYS.inboxFor(userId))) ?? [];
+        return [userId, Array.isArray(list) ? list : []];
+      }),
+    );
+
+    return Object.fromEntries(entries);
+  } catch (error) {
+    console.error('Failed to hydrate inbox from storage', error);
+    return {};
+  }
+}
+
+function ensureInboxIndex(inboxByUser) {
+  const index = Object.keys(inboxByUser);
+  schedulePersist(STORAGE_KEYS.inboxIndex, index);
+}
+
+function buildItemsFromGenerator(quiz, overridesItems) {
+  if (Array.isArray(overridesItems) && overridesItems.length) {
+    return overridesItems.map((item) => ({
+      id: item.id ?? `qitm_${nanoid(8)}`,
+      question: item.question ?? '',
+      options: item.options ?? [],
+      answer: item.answer ?? '',
+    }));
+  }
+
+  if (!quiz) return [];
+
+  const levels = ['easy', 'intermediate', 'advanced'];
+  return levels
+    .flatMap((level) => quiz?.[level] ?? [])
+    .map((item) => ({
+      id: item.id ?? `qitm_${nanoid(8)}`,
+      question: item.prompt ?? '',
+      options: item.options ?? [],
+      answer:
+        typeof item.correctIndex === 'number'
+          ? item.options?.[item.correctIndex] ?? ''
+          : item.answer ?? '',
+      level: item.level ?? level,
+    }));
+}
+
+function notifyMock(payload) {
+  if (!payload) return;
+  console.info('[AscendaIA][notify]', payload);
+}
 
 export const useQuizzesStore = create((set, get) => ({
-  generatedQuizzes: [],
+  hydrated: false,
+  templates: [],
   assignments: [],
-  setGeneratedQuizzes: (quizzes) => set({ generatedQuizzes: quizzes }),
-  updateQuizMeta: (id, patch) =>
-    set({
-      generatedQuizzes: get().generatedQuizzes.map((quiz) =>
+  inboxByUser: {},
+  generatedQuizzes: [],
+
+  async hydrate() {
+    if (get().hydrated) return;
+
+    try {
+      const [templates, assignments, inboxByUser] = await Promise.all([
+        storage.getItem(STORAGE_KEYS.templates),
+        storage.getItem(STORAGE_KEYS.assignments),
+        loadInboxFromStorage(),
+      ]);
+
+      set({
+        templates: Array.isArray(templates) ? templates : [],
+        assignments: Array.isArray(assignments) ? assignments : [],
+        inboxByUser,
+        hydrated: true,
+      });
+    } catch (error) {
+      console.error('Failed to hydrate quizzes store', error);
+      set({ hydrated: true });
+    }
+  },
+
+  setGeneratedQuizzes(quizzes) {
+    set({ generatedQuizzes: Array.isArray(quizzes) ? quizzes : [] });
+  },
+
+  updateQuizMeta(id, patch) {
+    if (!id) return;
+    set(({ generatedQuizzes }) => ({
+      generatedQuizzes: generatedQuizzes.map((quiz) =>
         quiz.id === id ? { ...quiz, ...patch } : quiz,
       ),
-    }),
-  assignQuizzes: (quizIds, payload) => {
-    const now = Date.now();
-    const newAssignments = quizIds.map((quizId, index) => ({
-      id: `asgn_${now}_${index}`,
-      quizId,
-      ...payload,
-      status: 'assigned',
     }));
-    set({ assignments: [...get().assignments, ...newAssignments] });
-    return newAssignments;
   },
-  selectAssignmentsByUser: (login) =>
-    get().assignments.filter((assignment) => assignment.assignees?.includes(login)),
+
+  addTemplateFromGenerator(payload, overrides = {}) {
+    const baseQuiz = payload?.quiz ?? payload;
+    const now = Date.now();
+
+    const template = {
+      id: overrides.id ?? `qtpl_${nanoid(10)}`,
+      title: overrides.title ?? baseQuiz?.topic ?? 'Untitled Quiz',
+      description: overrides.description ?? baseQuiz?.source ?? '',
+      tags: Array.isArray(overrides.tags)
+        ? overrides.tags
+        : Array.isArray(baseQuiz?.tags)
+          ? baseQuiz.tags
+          : [],
+      difficulty: overrides.difficulty ?? overrides.level ?? 'Medium',
+      items: buildItemsFromGenerator(baseQuiz, overrides.items),
+      createdAt: overrides.createdAt ?? now,
+      updatedAt: overrides.updatedAt ?? now,
+      version: overrides.version ?? 1,
+      authorId: overrides.authorId ?? 'ascenda-ia',
+      archived: Boolean(overrides.archived ?? false),
+    };
+
+    set((state) => {
+      const templates = [...state.templates, template];
+      schedulePersist(STORAGE_KEYS.templates, templates);
+      return { templates };
+    });
+
+    notifyMock({
+      title: 'Saved to Course Library',
+      message: template.title,
+      toUserId: overrides.authorId ?? 'ascenda-ia',
+    });
+
+    return template;
+  },
+
+  updateTemplate(id, patch) {
+    if (!id) return null;
+
+    let updatedTemplate = null;
+    set((state) => {
+      const templates = state.templates.map((template) => {
+        if (template.id !== id) return template;
+
+        const now = Date.now();
+        updatedTemplate = {
+          ...template,
+          ...patch,
+          items: patch.items ? buildItemsFromGenerator(null, patch.items) : template.items,
+          version: template.version + 1,
+          updatedAt: now,
+        };
+        return updatedTemplate;
+      });
+
+      if (updatedTemplate) {
+        schedulePersist(STORAGE_KEYS.templates, templates);
+      }
+
+      return { templates };
+    });
+
+    return updatedTemplate;
+  },
+
+  duplicateTemplate(id) {
+    const original = get().templates.find((template) => template.id === id);
+    if (!original) return null;
+
+    const now = Date.now();
+    const duplicate = {
+      ...original,
+      id: `qtpl_${nanoid(10)}`,
+      title: `Copy of ${original.title}`,
+      version: 1,
+      createdAt: now,
+      updatedAt: now,
+      archived: false,
+    };
+
+    set((state) => {
+      const templates = [...state.templates, duplicate];
+      schedulePersist(STORAGE_KEYS.templates, templates);
+      return { templates };
+    });
+
+    return duplicate;
+  },
+
+  archiveTemplate(id, flag = true) {
+    if (!id) return null;
+
+    let archivedTemplate = null;
+    set((state) => {
+      const templates = state.templates.map((template) => {
+        if (template.id !== id) return template;
+        const updated = {
+          ...template,
+          archived: Boolean(flag),
+          updatedAt: Date.now(),
+        };
+        archivedTemplate = updated;
+        return updated;
+      });
+
+      if (archivedTemplate) {
+        schedulePersist(STORAGE_KEYS.templates, templates);
+      }
+
+      return { templates };
+    });
+
+    return archivedTemplate;
+  },
+
+  assignFromTemplate(templateId, payload) {
+    const template = get().templates.find((item) => item.id === templateId);
+    if (!template) {
+      throw new Error(`Template ${templateId} not found`);
+    }
+
+    const assignees = Array.from(new Set(payload?.assignees ?? [])).filter(Boolean);
+    if (!assignees.length) {
+      throw new Error('No assignees provided');
+    }
+
+    const now = Date.now();
+    const assignment = {
+      id: `asgn_${nanoid(10)}`,
+      templateId,
+      assignees,
+      dueDate: payload?.dueDate ?? null,
+      visibility: payload?.visibility ?? 'Private',
+      status: 'assigned',
+      createdAt: now,
+    };
+
+    const quizInstanceBase = {
+      templateId,
+      templateVersion: template.version,
+      title: template.title,
+      difficulty: template.difficulty,
+      items: template.items,
+      status: 'pending',
+      assignedAt: now,
+      dueDate: payload?.dueDate ?? null,
+      visibility: payload?.visibility ?? 'Private',
+      assignmentId: assignment.id,
+    };
+
+    const inboxUpdates = {};
+
+    set((state) => {
+      const assignments = [...state.assignments, assignment];
+      schedulePersist(STORAGE_KEYS.assignments, assignments);
+
+      const inboxByUser = { ...state.inboxByUser };
+
+      assignees.forEach((userId) => {
+        const quizInstance = {
+          ...quizInstanceBase,
+          id: `quiz_${nanoid(10)}`,
+          assigneeId: userId,
+        };
+
+        const inbox = Array.isArray(inboxByUser[userId])
+          ? [...inboxByUser[userId], quizInstance]
+          : [quizInstance];
+
+        inboxByUser[userId] = inbox;
+        inboxUpdates[userId] = inbox;
+      });
+
+      Object.entries(inboxUpdates).forEach(([userId, inbox]) => {
+        schedulePersist(STORAGE_KEYS.inboxFor(userId), inbox);
+      });
+      ensureInboxIndex(inboxByUser);
+
+      assignees.forEach((userId) => {
+        notifyMock({
+          toUserId: userId,
+          title: 'Assigned to you',
+          message: template.title,
+        });
+      });
+
+      return { assignments, inboxByUser };
+    });
+
+    return assignment;
+  },
+
+  pushToInbox(userId, quiz) {
+    if (!userId || !quiz) return null;
+
+    let storedQuiz = null;
+    set((state) => {
+      const inboxByUser = { ...state.inboxByUser };
+      const list = Array.isArray(inboxByUser[userId]) ? [...inboxByUser[userId]] : [];
+
+      storedQuiz = {
+        ...quiz,
+        id: quiz.id ?? `quiz_${nanoid(10)}`,
+      };
+
+      list.push(storedQuiz);
+      inboxByUser[userId] = list;
+
+      schedulePersist(STORAGE_KEYS.inboxFor(userId), list);
+      ensureInboxIndex(inboxByUser);
+
+      return { inboxByUser };
+    });
+
+    return storedQuiz;
+  },
+
+  markQuizDone(userId, quizId) {
+    if (!userId || !quizId) return null;
+
+    let updatedQuiz = null;
+    set((state) => {
+      const inboxByUser = { ...state.inboxByUser };
+      const list = Array.isArray(inboxByUser[userId]) ? [...inboxByUser[userId]] : [];
+
+      const updatedList = list.map((quiz) => {
+        if (quiz.id !== quizId) return quiz;
+        updatedQuiz = {
+          ...quiz,
+          status: 'done',
+          completedAt: Date.now(),
+        };
+        return updatedQuiz;
+      });
+
+      inboxByUser[userId] = updatedList;
+      schedulePersist(STORAGE_KEYS.inboxFor(userId), updatedList);
+      ensureInboxIndex(inboxByUser);
+
+      if (updatedQuiz?.assignmentId) {
+        notifyMock({
+          toUserId: updatedQuiz.assignmentId,
+          title: 'Quiz completed',
+          message: updatedQuiz.title,
+        });
+      }
+
+      return { inboxByUser };
+    });
+
+    return updatedQuiz;
+  },
 }));
+

--- a/Ascenda Padrinho att/src/utils/index.js
+++ b/Ascenda Padrinho att/src/utils/index.js
@@ -2,8 +2,10 @@ export const PAGE_URLS = {
   Dashboard: '/',
   Interns: '/interns',
   ContentManagement: '/content',
-  AscendaIA: '/ascenda/ai-quizzes',
-  AscendaIAAssign: '/ascenda/ai-quizzes/assign',
+  AscendaIABase: '/ascenda-ia',
+  AscendaIA: '/ascenda-ia/generator',
+  AscendaIAAssign: '/ascenda-ia/assign',
+  AscendaIALibrary: '/ascenda-ia/library',
   VacationRequests: '/vacation-requests',
   Reports: '/reports',
 };


### PR DESCRIPTION
## Summary
- add a Course Library page with filtering, template cards, editing, duplication, archiving, and assignment modal
- persist quiz templates, assignments, and inbox data with the quizzes store and a localforage-compatible shim
- connect the generator and assign panels to the library, update toasts, and localize new UI strings

## Testing
- npm run build *(fails: missing registry access for i18next in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecddebca84832d816c2715a09b2546